### PR TITLE
Add championships schema foundation and ADR for multi-day events.

### DIFF
--- a/docs/architecture/ADR-0001-championships-multi-day.md
+++ b/docs/architecture/ADR-0001-championships-multi-day.md
@@ -1,0 +1,146 @@
+# ADR-0001: Multi-day Competitions via Championships Wrapper
+
+_This document is an ADR entry in the Architecture Decision Log (ADL)._
+
+## Status
+Accepted
+
+## Date
+2026-04-27
+
+## Context
+- Most events are single-day tournaments and should keep using the current `Tournament` flow unchanged.
+- Multi-day events are infrequent (around three per year) and should not increase complexity in the default tournament UI.
+- We need:
+  - per-day execution with existing round/group/score mechanics,
+  - combined standings across days,
+  - day 2+ pre-seeding from combined standings,
+  - organizer override of pre-seeded groups,
+  - late joins and participant drops handled explicitly.
+
+## Decision
+Implement multi-day events as a separate top-level concept named `Championship`, where each day is an existing `Tournament`.
+
+### Core model
+- Add `Championship`.
+- Add `ChampionshipRound` with ordered links to `Tournament` (`dayOrder`, `tournamentId`).
+- Use a single canonical relation (`ChampionshipRound.tournamentId -> Tournament.id`) and do not store a backward FK on `Tournament`.
+- Add `ChampionshipRegistration` keyed by `membershipNo` for cross-day participant identity.
+- Store `competitorNumber` on `ChampionshipRegistration` (unique within a championship) so the same competitor number carries across all rounds.
+- Add `Participant.competitorNumber` as a tournament-scoped stable competitor identifier (`unique(tournamentId, competitorNumber)`).
+
+### Modeling note
+- The previous back-reference approach (`Tournament.championshipDayId`) was dropped to avoid dual-source-of-truth synchronization.
+- Standalone tournaments are queried through relation-null checks (`championshipRound IS NULL`) instead of scalar `championshipDayId IS NULL`.
+
+### Behavioral rules
+- Day 1 groups are manual.
+- Day 2+ groups are auto-seeded from combined standings using adjacent blocks:
+  - example (`groupSize=4`): `1-4`, `5-8`, `9-12`.
+- Tail handling:
+  - rebalance tail blocks to maximize full groups,
+  - if still impossible, allow a smaller final group (example: `1-4`, `5-7`).
+- After auto-seed, organizers can fully edit groups in normal group assignment UI.
+- Late join on day `N`:
+  - default prior-day backfill is DNC (`setDNC`) for days `< N`.
+- Drop handling:
+  - no automatic DNC for later days,
+  - organizer can run bulk action to set DNC on remaining days.
+
+### Visibility rules
+- Default tournament lists show only standalone tournaments by filtering tournaments with no linked `ChampionshipRound`.
+- Championship day tournaments appear in `My Championships` (and direct links), not in normal tournament lists.
+
+## Alternatives considered
+
+### Rejected: Embed days inside `Tournament`
+- Would require new day-specific score/group models and broad refactors in core tournament actions and screens.
+- Higher regression risk for the primary single-day workflow.
+- Larger PRs and harder review path.
+
+## Consequences
+
+### Positive
+- Reuses existing tournament engine for each day (round formats, groups, scoring, publishing).
+- Keeps default tournament workflows simple.
+- Enables incremental rollout with low compatibility risk.
+
+### Trade-offs
+- Requires cross-day identity layer (`ChampionshipRegistration`).
+- Needs orchestration logic for combined standings and seeding.
+
+## Backward compatibility
+- Existing tournaments remain standalone unless linked by a `ChampionshipRound` row.
+- No breaking changes to core score/group actions for standard tournament flows.
+- Championship behavior is introduced via new actions and UI surfaces.
+
+## Implementation milestones (small reviewable slices)
+
+### M1 — Schema foundation (no behavior change)
+- Add schema objects:
+  - `Championship`
+  - `ChampionshipRound`
+  - `ChampionshipRegistration`
+- Add indexes for round lookups and championship ordering.
+- Migration default: existing tournaments remain standalone by having no linked championship round rows.
+
+### M2 — Championship actions (dark launch)
+- Add championship CRUD + day attach/detach actions.
+- Enforce transactional integrity on `ChampionshipRound` creation/removal with linked tournament references.
+- Keep features non-discoverable in existing user flows.
+
+### M3 — Standalone tournament list guardrail
+- Update default list queries to relation-null (`championshipRound IS NULL`).
+- Add explicit championship-scoped list queries for day tournaments.
+
+### M4 — My Championships UI shell
+- Add navigation entry and list/detail pages.
+- Support day ordering and deep links to existing `/tournaments/[tId]` pages.
+
+### M5 — Combined standings engine
+- Add library and actions for combined standings (sum raw scores, current tie semantics).
+- Use `membershipNo` identity mapping.
+
+### Participant naming policy
+- `membershipNo` is the stable championship identity.
+- Display name in combined views uses the most recent known participant name (latest championship round containing that `membershipNo`), not a first-entry snapshot.
+- `competitorNumber` for championship artifacts (badges/documents) comes from `ChampionshipRegistration` and remains stable across all championship rounds.
+- `competitorNumber` is assigned by the system at championship registration time, using the next sequential number within that championship (`max + 1`), and is immutable afterward.
+
+### M6 — Auto-seed and manual override
+- Add day 2+ auto-seed (adjacent blocks + tail rebalance).
+- Keep post-seed manual editing fully enabled in existing group UI.
+
+### M7 — Late join / drop operations
+- Add day-N participant add with prior-day DNC backfill.
+- Add organizer bulk action to set DNC on remaining days after drops.
+
+### M8 — Optional public championship results
+- Add championship results page composing per-day and combined views.
+- Keep existing tournament publish/share behavior unchanged.
+
+### M9 — Hardening
+- Add integration/regression coverage and runbook notes.
+- Verify no regressions for standalone tournament creation/scoring/results.
+
+## Test and acceptance criteria
+- Standalone tournaments: unchanged behavior for create, groups, scoring, publish, results.
+- Championships:
+  - linked day tournaments work end-to-end,
+  - combined standings match manual calculations,
+  - seeding follows adjacent + tail rules,
+  - post-seed group edits persist until explicit re-seed,
+  - late join creates prior-day DNC by default,
+  - drop does not auto-DNC later days; bulk DNC action works.
+
+## Decision diagram
+```mermaid
+flowchart TD
+  championship[Championship] --> championshipRound[ChampionshipRound]
+  championshipRound --> dayTournament[TournamentByDay]
+  dayTournament --> dayScores[ParticipantScore]
+  dayScores --> combinedStandings[CombinedStandings]
+  combinedStandings --> seedDayN[AutoSeedDayN]
+  seedDayN --> dayGroups[GroupAssignment]
+  dayGroups --> manualEdits[OrganizerManualEdits]
+```

--- a/prisma/migrations/20251126015126_add_tournament_end_count_and_group_size/migration.sql
+++ b/prisma/migrations/20251126015126_add_tournament_end_count_and_group_size/migration.sql
@@ -13,6 +13,3 @@ WHERE t."formatId" = rf.id;
 ALTER TABLE "Tournament" ALTER COLUMN "endCount" SET NOT NULL,
 ALTER COLUMN "groupSize" SET NOT NULL;
 
-
-
-1

--- a/prisma/migrations/20260427001000_championships_foundation/migration.sql
+++ b/prisma/migrations/20260427001000_championships_foundation/migration.sql
@@ -1,0 +1,63 @@
+-- CreateTable
+CREATE TABLE "Championship" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "organizerClub" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Championship_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChampionshipRound" (
+    "id" TEXT NOT NULL,
+    "championshipId" TEXT NOT NULL,
+    "dayOrder" INTEGER NOT NULL,
+    "label" TEXT,
+    "tournamentId" TEXT NOT NULL,
+
+    CONSTRAINT "ChampionshipRound_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChampionshipRegistration" (
+    "id" TEXT NOT NULL,
+    "championshipId" TEXT NOT NULL,
+    "membershipNo" TEXT NOT NULL,
+    "competitorNumber" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChampionshipRegistration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Championship_organizerClub_idx" ON "Championship"("organizerClub");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRound_tournamentId_key" ON "ChampionshipRound"("tournamentId");
+
+-- CreateIndex
+CREATE INDEX "ChampionshipRound_championshipId_idx" ON "ChampionshipRound"("championshipId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRound_championshipId_dayOrder_key" ON "ChampionshipRound"("championshipId", "dayOrder");
+
+-- CreateIndex
+CREATE INDEX "ChampionshipRegistration_championshipId_idx" ON "ChampionshipRegistration"("championshipId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRegistration_championshipId_membershipNo_key" ON "ChampionshipRegistration"("championshipId", "membershipNo");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRegistration_championshipId_competitorNumber_key" ON "ChampionshipRegistration"("championshipId", "competitorNumber");
+
+-- CreateIndex
+ALTER TABLE "ChampionshipRound" ADD CONSTRAINT "ChampionshipRound_championshipId_fkey" FOREIGN KEY ("championshipId") REFERENCES "Championship"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChampionshipRound" ADD CONSTRAINT "ChampionshipRound_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "Tournament"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChampionshipRegistration" ADD CONSTRAINT "ChampionshipRegistration_championshipId_fkey" FOREIGN KEY ("championshipId") REFERENCES "Championship"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260427004000_add_competitor_number_to_participant/migration.sql
+++ b/prisma/migrations/20260427004000_add_competitor_number_to_participant/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Participant" ADD COLUMN "competitorNumber" INTEGER;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participant_tournamentId_competitorNumber_key" ON "Participant"("tournamentId", "competitorNumber");

--- a/prisma/migrations/20260427085000_refactor_championship_models/migration.sql
+++ b/prisma/migrations/20260427085000_refactor_championship_models/migration.sql
@@ -1,0 +1,61 @@
+-- DropForeignKey
+ALTER TABLE "ChampionshipDay" DROP CONSTRAINT "ChampionshipDay_championshipId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ChampionshipDay" DROP CONSTRAINT "ChampionshipDay_tournamentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Tournament" DROP CONSTRAINT "Tournament_championshipDayId_fkey";
+
+-- DropIndex
+DROP INDEX "ChampionshipRegistration_championshipId_registrationKey_key";
+
+-- DropIndex
+DROP INDEX "Tournament_championshipDayId_key";
+
+-- DropIndex
+DROP INDEX "Tournament_organizerClub_championshipDayId_idx";
+
+-- AlterTable
+ALTER TABLE "ChampionshipRegistration" DROP COLUMN "displayNameSnapshot",
+DROP COLUMN "registrationKey",
+ADD COLUMN     "competitorNumber" INTEGER NOT NULL,
+ADD COLUMN     "membershipNo" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Tournament" DROP COLUMN "championshipDayId";
+
+-- DropTable
+DROP TABLE "ChampionshipDay";
+
+-- CreateTable
+CREATE TABLE "ChampionshipRound" (
+    "id" TEXT NOT NULL,
+    "championshipId" TEXT NOT NULL,
+    "dayOrder" INTEGER NOT NULL,
+    "label" TEXT,
+    "tournamentId" TEXT NOT NULL,
+
+    CONSTRAINT "ChampionshipRound_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRound_tournamentId_key" ON "ChampionshipRound"("tournamentId");
+
+-- CreateIndex
+CREATE INDEX "ChampionshipRound_championshipId_idx" ON "ChampionshipRound"("championshipId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRound_championshipId_dayOrder_key" ON "ChampionshipRound"("championshipId", "dayOrder");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRegistration_championshipId_membershipNo_key" ON "ChampionshipRegistration"("championshipId", "membershipNo");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChampionshipRegistration_championshipId_competitorNumber_key" ON "ChampionshipRegistration"("championshipId", "competitorNumber");
+
+-- AddForeignKey
+ALTER TABLE "ChampionshipRound" ADD CONSTRAINT "ChampionshipRound_championshipId_fkey" FOREIGN KEY ("championshipId") REFERENCES "Championship"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChampionshipRound" ADD CONSTRAINT "ChampionshipRound_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "Tournament"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -131,6 +131,7 @@ model Tournament {
   formatId          String
   organizerClub     String
   format            RoundFormat        @relation(fields: [formatId], references: [id], onDelete: Restrict)
+  championshipRound ChampionshipRound? @relation("ChampionshipRoundTournament")
   endCount          Int
   groupSize         Int
   participants      Participant[]
@@ -151,6 +152,7 @@ model Participant {
   id               String            @id @default(cuid())
   name             String
   membershipNo     String
+  competitorNumber Int?
   ageGroupId       String
   categoryId       String
   tournamentId     String
@@ -164,6 +166,7 @@ model Participant {
   participantScore ParticipantScore? @relation("ParticipantScore")
 
   @@unique([tournamentId, membershipNo])
+  @@unique([tournamentId, competitorNumber])
 }
 
 model GroupAssignment {
@@ -198,6 +201,45 @@ model IFAFBowStyleMapping {
   equipmentCategory   EquipmentCategory @relation(fields: [equipmentCategoryId], references: [id], onDelete: Cascade)
 
   @@unique([equipmentCategoryId])
+}
+
+model Championship {
+  id            String                   @id @default(cuid())
+  name          String
+  organizerClub String
+  createdAt     DateTime                 @default(now())
+  updatedAt     DateTime                 @updatedAt
+  rounds        ChampionshipRound[]
+  registrations ChampionshipRegistration[]
+
+  @@index([organizerClub])
+}
+
+model ChampionshipRound {
+  id             String       @id @default(cuid())
+  championshipId String
+  dayOrder       Int
+  label          String?
+  tournamentId   String       @unique
+  championship   Championship @relation(fields: [championshipId], references: [id], onDelete: Cascade)
+  tournament     Tournament   @relation("ChampionshipRoundTournament", fields: [tournamentId], references: [id], onDelete: Restrict)
+
+  @@unique([championshipId, dayOrder])
+  @@index([championshipId])
+}
+
+model ChampionshipRegistration {
+  id             String       @id @default(cuid())
+  championshipId String
+  membershipNo   String
+  competitorNumber Int
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  championship   Championship @relation(fields: [championshipId], references: [id], onDelete: Cascade)
+
+  @@unique([championshipId, membershipNo])
+  @@unique([championshipId, competitorNumber])
+  @@index([championshipId])
 }
 
 model IFAFAgeGenderMapping {

--- a/src/app/auth.ts
+++ b/src/app/auth.ts
@@ -23,7 +23,7 @@ const handler = NextAuth({
         async session(params) {
             const { session, user } = params
             if (user) {
-                const userWithRoles = await prismaOrThrow("authenticate user").user.findUnique({ where: { id: user.id }, include: { organizerRoles: true } }).catch(e => {
+                const userWithRoles = await prismaOrThrow("authenticate user").user.findUnique({ where: { id: user.id }, include: { organizerRoles: true } }).catch((e: unknown) => {
                     console.error("Failed to fetch user roles:", e)
                     return null
                 })

--- a/src/app/tournaments/[tId]/csvImportActions.ts
+++ b/src/app/tournaments/[tId]/csvImportActions.ts
@@ -157,6 +157,7 @@ function processRow(
             tournamentId,
             name: results[0].value as string,
             membershipNo: results[1].value as string,
+            competitorNumber: null,
             genderGroup: results[2].value as GenderGroup,
             ageGroupId: results[3].value as string,
             categoryId: results[4].value as string,

--- a/src/components/Account.tsx
+++ b/src/components/Account.tsx
@@ -4,9 +4,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 export default function Account() {
-    const {data: session} = useSession()
+    const { data: session } = useSession()
     const router = useRouter()
-    
+
     const isAdmin = session?.isAdmin
 
     return (
@@ -14,7 +14,7 @@ export default function Account() {
             <div tabIndex={0} role="button" className="btn btn-ghost btn-sm">
                 {session?.user?.name || "Unauthenticated"}
             </div>
-            <ul tabIndex={0} className="menu menu-sm dropdown-content mt-3 z-[1] shadow bg-base-200 rounded-box w-52">
+            <ul tabIndex={0} className="menu menu-sm dropdown-content mt-3 z-1 shadow bg-base-200 rounded-box w-52">
                 {isAdmin && (<li className="w-full p-0"><Link className="btn btn-neutral btn-sm btn-ghost" href="/organizers">TOs</Link></li>)}
                 <li className="w-full p-0"><button className="btn btn-neutral btn-sm btn-ghost" onClick={() => {
                     signOut().then(() => router.refresh()).catch(e => {


### PR DESCRIPTION
This introduces Championship/ChampionshipRound/ChampionshipRegistration data models, adds stable competitor numbering, and documents the architecture decisions and rollout rules while preserving existing tournament workflows.

Made-with: Cursor