### PR TITLE
M7: Championship competitor roster with CSV import

### DIFF
--- a/docs/architecture/ADR-0001-championships-multi-day.md
+++ b/docs/architecture/ADR-0001-championships-multi-day.md
@@ -56,8 +56,8 @@ Championship access is **not** a separate role table. It is a **per-club upgrade
 - Add `Championship`.
 - Add `ChampionshipRound` with ordered links to `Tournament` (`dayOrder`, `tournamentId`).
 - Use a single canonical relation (`ChampionshipRound.tournamentId -> Tournament.id`) and do not store a backward FK on `Tournament`.
-- Add `ChampionshipRegistration` per competitor in a championship: association `membershipNo` plus system-assigned championship `competitorNumber` (see identity rules below).
-- On each day enroll, copy both onto that day’s `Participant` row (`unique(tournamentId, membershipNo)` and `unique(tournamentId, competitorNumber)`).
+- Add `ChampionshipRegistration` per competitor in a championship: full participant profile (name, age division, equipment category, gender, club, `membershipNo`) plus system-assigned championship `competitorNumber` (see identity rules below).
+- On each day enroll, copy the registration profile onto that day’s `Participant` row (`unique(tournamentId, membershipNo)` and `unique(tournamentId, competitorNumber)`).
 
 ### Modeling note
 - The previous back-reference approach (`Tournament.championshipDayId`) was dropped to avoid dual-source-of-truth synchronization.
@@ -89,8 +89,8 @@ Organizers must be able to run a multi-day event end-to-end in the app without m
 
 1. **Create championship** — name + organizer club (from session roles).
 2. **Configure days** — append championship days in order; each day creates a new `Tournament` and `ChampionshipRound` link; remove a day only when appropriate (detach).
-3. **Register championship competitors** — add rows to `ChampionshipRegistration` (stable `membershipNo`, system-assigned `competitorNumber`).
-4. **Enroll into days** — for a selected day, create `Participant` rows on that day’s tournament for registered competitors (profile fields: entered at enroll or copied from the competitor’s latest participant row in this championship).
+3. **Register championship competitors** — add rows to `ChampionshipRegistration` with the full participant profile (same fields as a day `Participant` except day-specific check-in) plus system-assigned `competitorNumber`.
+4. **Enroll into days** — for a selected day, create `Participant` rows on that day’s tournament by copying from `ChampionshipRegistration` (no second data-entry step).
 5. **Run each day** — from the championship detail, open the existing tournament flows for that day: participants, **groups** (`/tournaments/[tId]/groups`), **scores** (`/tournaments/[tId]/scores`). No duplicate group/score UIs under `/championships`.
 6. **Later milestones** — combined standings, day 2+ auto-seed, late join/drop, optional public results (M9–M12).
 
@@ -110,9 +110,11 @@ These are **different fields**; do not conflate them.
 
 ### Enrollment rules
 - A competitor must be in `ChampionshipRegistration` before enrollment into any day.
-- On enroll, copy from registration to day `Participant`:
+- On enroll, copy from registration to day `Participant` (profile + identity):
+  - `Participant.name`, `ageGroupId`, `categoryId`, `club`, `genderGroup` ← registration
   - `Participant.membershipNo` ← `ChampionshipRegistration.membershipNo`
   - `Participant.competitorNumber` ← `ChampionshipRegistration.competitorNumber`
+- Profile edits at championship level update `ChampionshipRegistration`; re-enroll or sync rules for already-enrolled days are documented in the runbook (M13).
 - One `Participant` per `(tournamentId, membershipNo)` per day; re-enroll on the same day is an update, not a duplicate.
 - Enrolling on day `N` without prior day rows does not auto-create participants on earlier days (late join / DNC backfill remains M11).
 - Unenroll from a day: remove `Participant` (and dependent group/score rows per existing tournament delete rules) without removing `ChampionshipRegistration`.
@@ -135,6 +137,10 @@ These are **different fields**; do not conflate them.
 ## Follow-up PR (championship cleanup)
 - **Remove `reorderRounds`** from `src/app/championships/championshipActions.ts` (shipped in M2, never used by UI or tests).
 - Confirm `addRoundTournament` / day-create flow only assigns the next sequential `dayOrder`.
+
+## Follow-up PR (championship days UX)
+- **Add-day default date:** when opening Add day, pre-fill the date picker with the day after the latest existing day’s `Tournament.date` (not `new Date()` / today). First day may still default to today or another agreed rule.
+- **Day card shows date:** on championship detail, each day card in `ChampionshipRoundsList` should display the linked tournament date (format consistently with `TournamentDayPicker` / elsewhere).
 
 ## Consequences
 
@@ -205,21 +211,21 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - Day list shows fixed order, label, tournament name, and links to overview, **groups**, and **scores** for each day.
 - **UI test:** add two days in sequence → day numbers are 1 then 2 → open groups/scores from championship detail → remove a day link (per rules).
 
-### M7 — Championship competitor roster
-- Register competitors (`membershipNo` → system `competitorNumber`); list roster on championship detail.
+### M7 — Championship competitor roster ✓
+- Register competitors with full participant profile (`membershipNo`, name, division, category, gender, club) → system `competitorNumber`; list roster on championship detail.
 - Remove registration only when not enrolled on any day (document cascade in runbook).
-- **UI test:** register two competitors → see assigned competitor numbers → remove one not enrolled on any day.
+- **UI test:** register two competitors with full profiles → see names, numbers, and divisions → remove one not enrolled on any day.
 
 ### M8 — Enroll competitors into days
-- Day enrollment actions: create/update `Participant` on the day tournament from `ChampionshipRegistration` (copy `membershipNo` and `competitorNumber` separately — see identity rules).
-- Per day: show enrolled vs registered-not-enrolled; single/bulk enroll; profile form at enroll or copy from latest in-championship `Participant` for that `membershipNo`.
+- Day enrollment actions: create/update `Participant` on the day tournament by copying all fields from `ChampionshipRegistration` (see enrollment rules).
+- Per day: show enrolled vs registered-not-enrolled; single/bulk enroll (no profile form at enroll unless registration is edited separately).
 - Unenroll from a day without removing championship registration.
 - **UI test:** enroll roster members on day 1 → they appear on that day’s tournament participants → unenroll one → championship registration unchanged.
 
 ### Participant naming policy
 - **Cross-day person key:** `membershipNo` (association ID) — used to aggregate combined standings and find the same archer across championship days.
 - **Championship bib:** `competitorNumber` on `ChampionshipRegistration`, assigned at roster registration (`max + 1` within the championship), immutable, copied to each enrolled day’s `Participant`.
-- **Display name** in combined views: most recent `Participant.name` for that `membershipNo` on any day of this championship (not a snapshot on `ChampionshipRegistration`).
+- **Display name** in combined views: `ChampionshipRegistration.name` (source of truth at registration); enrolled day `Participant.name` is a copy at enroll time.
 
 ### M9 — Combined standings (organizer view)
 - Combined standings library and actions (sum raw scores, current tie semantics; `membershipNo` identity).
@@ -258,7 +264,7 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - **M4:** CO power-up enforced on `Organizer`; TO without `canManageChampionships` cannot access `/championships`; TO+CO can browse and open linked day tournaments.
 - **M5:** create and rename championships in UI.
 - **M6:** append days in fixed order, remove day when allowed; jump to groups/scores from championship detail.
-- **M7:** register championship roster with stable competitor numbers.
+- **M7:** register championship roster with full profile and stable competitor numbers.
 - **M8:** enroll/unenroll on days; day `Participant` has registration `membershipNo` and registration `competitorNumber` (distinct fields).
 - **M9:** combined standings on championship detail match manual totals across days.
 - **M10:** day 2+ auto-seed produces correct groups; manual override in tournament groups UI works.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-comp",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/migrations/20260522000956_championship_registration_profile/migration.sql
+++ b/prisma/migrations/20260522000956_championship_registration_profile/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - Added the required column `ageGroupId` to the `ChampionshipRegistration` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `categoryId` to the `ChampionshipRegistration` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `genderGroup` to the `ChampionshipRegistration` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `name` to the `ChampionshipRegistration` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ChampionshipRegistration" ADD COLUMN     "ageGroupId" TEXT NOT NULL,
+ADD COLUMN     "categoryId" TEXT NOT NULL,
+ADD COLUMN     "club" TEXT,
+ADD COLUMN     "genderGroup" "GenderGroup" NOT NULL,
+ADD COLUMN     "name" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "ChampionshipRegistration" ADD CONSTRAINT "ChampionshipRegistration_ageGroupId_fkey" FOREIGN KEY ("ageGroupId") REFERENCES "AgeGroup"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChampionshipRegistration" ADD CONSTRAINT "ChampionshipRegistration_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "EquipmentCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260524003931_championship_registration_club_required/migration.sql
+++ b/prisma/migrations/20260524003931_championship_registration_club_required/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `club` on table `ChampionshipRegistration` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "ChampionshipRegistration" ALTER COLUMN "club" SET NOT NULL;

--- a/prisma/migrations/20260524005759_championship_is_archive/migration.sql
+++ b/prisma/migrations/20260524005759_championship_is_archive/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Championship" ADD COLUMN     "isArchive" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,17 +104,19 @@ model Organizer {
 }
 
 model EquipmentCategory {
-  id                  String               @id
-  name                String               @unique
-  participants        Participant[]
-  ifafBowStyleMapping IFAFBowStyleMapping?
+  id                       String                      @id
+  name                     String                      @unique
+  participants             Participant[]
+  championshipRegistrations ChampionshipRegistration[]
+  ifafBowStyleMapping      IFAFBowStyleMapping?
 }
 
 model AgeGroup {
-  id                    String                 @id
-  name                  String                 @unique
-  participants          Participant[]
-  ifafAgeGenderMappings IFAFAgeGenderMapping[]
+  id                        String                      @id
+  name                      String                      @unique
+  participants              Participant[]
+  championshipRegistrations ChampionshipRegistration[]
+  ifafAgeGenderMappings     IFAFAgeGenderMapping[]
 }
 
 model RoundFormat {
@@ -208,6 +210,7 @@ model Championship {
   id            String                   @id @default(cuid())
   name          String
   organizerClub String
+  isArchive     Boolean                  @default(false)
   createdAt     DateTime                 @default(now())
   updatedAt     DateTime                 @updatedAt
   rounds        ChampionshipRound[]
@@ -230,13 +233,20 @@ model ChampionshipRound {
 }
 
 model ChampionshipRegistration {
-  id             String       @id @default(cuid())
-  championshipId String
-  membershipNo   String
+  id               String            @id @default(cuid())
+  championshipId   String
+  membershipNo     String
   competitorNumber Int
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
-  championship   Championship @relation(fields: [championshipId], references: [id], onDelete: Cascade)
+  name             String
+  ageGroupId       String
+  categoryId       String
+  club             String
+  genderGroup      GenderGroup
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  championship     Championship      @relation(fields: [championshipId], references: [id], onDelete: Cascade)
+  ageGroup         AgeGroup          @relation(fields: [ageGroupId], references: [id], onDelete: Restrict)
+  category         EquipmentCategory @relation(fields: [categoryId], references: [id], onDelete: Restrict)
 
   @@unique([championshipId, membershipNo])
   @@unique([championshipId, competitorNumber])

--- a/src/app/championships/ChampionshipSummaryCard.tsx
+++ b/src/app/championships/ChampionshipSummaryCard.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import ConfirmingButton from "@/components/ConfirmingButton"
+import Link from "next/link"
+import {
+    ArchiveBoxArrowDownIcon,
+    ArrowUturnUpIcon,
+    HandThumbUpIcon,
+} from "@heroicons/react/24/outline"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { archiveChampionship, unarchiveChampionship, type ChampionshipShellRow } from "./championshipActions"
+import { competitorsRegisteredLabel } from "./competitorsRegisteredLabel"
+
+export default function ChampionshipSummaryCard({
+    row,
+    isAdmin,
+    onArchived,
+    onUnarchived,
+}: {
+    row: ChampionshipShellRow
+    isAdmin: boolean
+    onArchived: (id: string) => void
+    onUnarchived: (row: ChampionshipShellRow) => void
+}) {
+    const router = useRouter()
+    const [data, setData] = useState(row)
+    const dayCount = data.rounds.length
+    const regCount = data._count.registrations
+
+    return (
+        <div className="card w-full max-w-md bg-base-300 shadow-sm">
+            <div className="card-body gap-2">
+                <div className="flex flex-wrap gap-2">
+                    <span className="badge badge-info badge-outline">{data.organizerClub}</span>
+                    {data.isArchive ? <span className="badge badge-warning">Archived</span> : null}
+                </div>
+                <h2 className="card-title text-base md:text-lg">{data.name}</h2>
+                <div className="flex flex-wrap gap-2 text-sm">
+                    <span className="badge badge-ghost">{dayCount} day{dayCount === 1 ? "" : "s"}</span>
+                    <span className="badge badge-ghost">{competitorsRegisteredLabel(regCount)}</span>
+                </div>
+                <div className="card-actions justify-end flex-wrap gap-2">
+                    <Link className="btn btn-primary btn-sm" href={`/championships/${data.id}`}>
+                        Open
+                    </Link>
+                    {!data.isArchive ? (
+                        <ConfirmingButton
+                            className="inline"
+                            action={() =>
+                                archiveChampionship(data.id).then((updated) => {
+                                    setData(updated)
+                                    onArchived(updated.id)
+                                    router.refresh()
+                                })
+                            }
+                            baseButton={{
+                                className: "btn btn-warning btn-sm",
+                                children: (
+                                    <>
+                                        <ArchiveBoxArrowDownIcon width={16} />
+                                        Archive
+                                    </>
+                                ),
+                            }}
+                            confirmButton={{
+                                className: "btn btn-warning btn-sm",
+                                children: (
+                                    <>
+                                        <HandThumbUpIcon width={16} />
+                                        Confirm?
+                                    </>
+                                ),
+                            }}
+                        />
+                    ) : null}
+                    {data.isArchive && isAdmin ? (
+                        <ConfirmingButton
+                            className="inline"
+                            action={() =>
+                                unarchiveChampionship(data.id).then((updated) => {
+                                    setData(updated)
+                                    onUnarchived(updated)
+                                    router.refresh()
+                                })
+                            }
+                            baseButton={{
+                                className: "btn btn-info btn-sm",
+                                children: (
+                                    <>
+                                        <ArrowUturnUpIcon width={16} />
+                                        Unarchive
+                                    </>
+                                ),
+                            }}
+                            confirmButton={{
+                                className: "btn btn-info btn-sm",
+                                children: (
+                                    <>
+                                        <HandThumbUpIcon width={16} />
+                                        Confirm?
+                                    </>
+                                ),
+                            }}
+                        />
+                    ) : null}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/app/championships/ChampionshipsList.tsx
+++ b/src/app/championships/ChampionshipsList.tsx
@@ -1,55 +1,78 @@
 "use client"
 
-import Link from "next/link"
+import { useSession } from "next-auth/react"
 import { useEffect, useState } from "react"
-import { competitorsRegisteredLabel } from "./competitorsRegisteredLabel"
+import ChampionshipSummaryCard from "./ChampionshipSummaryCard"
 import { listMyChampionships, type ChampionshipShellRow } from "./championshipActions"
 
-function ChampionshipSummaryCard({ row }: { row: ChampionshipShellRow }) {
-    const dayCount = row.rounds.length
-    const regCount = row._count.registrations
-
-    return (
-        <div className="card w-full max-w-md bg-base-300 shadow-sm">
-            <div className="card-body gap-2">
-                <h2 className="card-title text-base md:text-lg">{row.name}</h2>
-                <div className="flex flex-wrap gap-2 text-sm">
-                    <span className="badge badge-info badge-outline">{row.organizerClub}</span>
-                    <span className="badge badge-ghost">{dayCount} day{dayCount === 1 ? "" : "s"}</span>
-                    <span className="badge badge-ghost">{competitorsRegisteredLabel(regCount)}</span>
-                </div>
-                <div className="card-actions justify-end">
-                    <Link className="btn btn-primary btn-sm" href={`/championships/${row.id}`}>
-                        Open
-                    </Link>
-                </div>
-            </div>
-        </div>
-    )
-}
-
 export default function ChampionshipsList() {
+    const { data: session } = useSession()
     const [rows, setRows] = useState<ChampionshipShellRow[]>([])
+    const [includeArchive, setIncludeArchive] = useState(false)
 
     useEffect(() => {
-        listMyChampionships().then((data) => {
+        listMyChampionships(includeArchive).then((data) => {
             setRows(data ?? [])
         })
-    }, [])
+    }, [includeArchive])
+
+    function onArchived(id: string) {
+        if (!includeArchive) {
+            setRows((prev) => prev.filter((row) => row.id !== id))
+        }
+    }
+
+    function onUnarchived(row: ChampionshipShellRow) {
+        setRows((prev) => prev.map((item) => (item.id === row.id ? row : item)))
+    }
 
     if (rows.length === 0) {
         return (
-            <p className="text-center text-base-content/70 py-8">
-                No championships yet for your organizer clubs.
-            </p>
+            <>
+                <ArchiveToggle includeArchive={includeArchive} onChange={setIncludeArchive} />
+                <p className="text-center text-base-content/70 py-8">
+                    No championships yet for your organizer clubs.
+                </p>
+            </>
         )
     }
 
     return (
-        <div className="w-full flex flex-wrap gap-4 mt-5 bg-primary p-5 rounded-sm justify-center">
-            {rows.map((row) => (
-                <ChampionshipSummaryCard key={row.id} row={row} />
-            ))}
+        <>
+            <ArchiveToggle includeArchive={includeArchive} onChange={setIncludeArchive} />
+            <div className="w-full flex flex-wrap gap-4 mt-5 bg-primary p-5 rounded-sm justify-center">
+                {rows.map((row) => (
+                    <ChampionshipSummaryCard
+                        key={row.id}
+                        row={row}
+                        isAdmin={!!session?.isAdmin}
+                        onArchived={onArchived}
+                        onUnarchived={onUnarchived}
+                    />
+                ))}
+            </div>
+        </>
+    )
+}
+
+function ArchiveToggle({
+    includeArchive,
+    onChange,
+}: {
+    includeArchive: boolean
+    onChange: (value: boolean) => void
+}) {
+    return (
+        <div className="divider">
+            <label className="label">
+                <input
+                    type="checkbox"
+                    checked={includeArchive}
+                    className="checkbox checkbox-accent rounded-lg"
+                    onChange={(evt) => onChange(evt.target.checked)}
+                />
+                <span className="text-accent">Include Archived</span>
+            </label>
         </div>
     )
 }

--- a/src/app/championships/[cId]/ChampionshipDaysSection.tsx
+++ b/src/app/championships/[cId]/ChampionshipDaysSection.tsx
@@ -12,11 +12,13 @@ export default function ChampionshipDaysSection({
     championshipName,
     organizerClub,
     rounds,
+    readOnly = false,
 }: {
     championshipId: string
     championshipName: string
     organizerClub: string
     rounds: ChampionshipRoundRow[]
+    readOnly?: boolean
 }) {
     const nextDayOrder = nextChampionshipDayOrder(rounds)
     const modalRef = useRef<FormModalHandle>(null)
@@ -29,25 +31,33 @@ export default function ChampionshipDaysSection({
         <section className="mt-6">
             <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
                 <h2 className="text-lg font-medium">Days (by order)</h2>
-                <button
-                    type="button"
-                    className="btn btn-success btn-sm"
-                    onClick={() => modalRef.current?.open()}
-                >
-                    <PlusCircleIcon width={20} />
-                    Add day
-                </button>
+                {!readOnly ? (
+                    <button
+                        type="button"
+                        className="btn btn-success btn-sm"
+                        onClick={() => modalRef.current?.open()}
+                    >
+                        <PlusCircleIcon width={20} />
+                        Add day
+                    </button>
+                ) : null}
             </div>
-            <ChampionshipRoundsList championshipId={championshipId} rounds={rounds} />
-            <FormModal ref={modalRef}>
-                <AddChampionshipDayForm
-                    championshipId={championshipId}
-                    championshipName={championshipName}
-                    nextDayOrder={nextDayOrder}
-                    organizerClub={organizerClub}
-                    onClose={closeDialog}
-                />
-            </FormModal>
+            <ChampionshipRoundsList
+                championshipId={championshipId}
+                rounds={rounds}
+                readOnly={readOnly}
+            />
+            {!readOnly ? (
+                <FormModal ref={modalRef}>
+                    <AddChampionshipDayForm
+                        championshipId={championshipId}
+                        championshipName={championshipName}
+                        nextDayOrder={nextDayOrder}
+                        organizerClub={organizerClub}
+                        onClose={closeDialog}
+                    />
+                </FormModal>
+            ) : null}
         </section>
     )
 }

--- a/src/app/championships/[cId]/ChampionshipNameEdit.tsx
+++ b/src/app/championships/[cId]/ChampionshipNameEdit.tsx
@@ -9,9 +9,11 @@ import { updateChampionship } from "../championshipActions"
 export default function ChampionshipNameEdit({
     championshipId,
     initialName,
+    readOnly = false,
 }: {
     championshipId: string
     initialName: string
+    readOnly?: boolean
 }) {
     const router = useRouter()
     const [displayName, setDisplayName] = useState(initialName)
@@ -81,9 +83,11 @@ export default function ChampionshipNameEdit({
     return (
         <div className="flex flex-wrap items-center gap-2">
             <h1 className="text-2xl font-semibold">{displayName}</h1>
-            <button type="button" className="btn btn-ghost btn-sm" onClick={startEdit} aria-label="Edit championship name">
-                <PencilSquareIcon width={20} />
-            </button>
+            {!readOnly ? (
+                <button type="button" className="btn btn-ghost btn-sm" onClick={startEdit} aria-label="Edit championship name">
+                    <PencilSquareIcon width={20} />
+                </button>
+            ) : null}
         </div>
     )
 }

--- a/src/app/championships/[cId]/ChampionshipRosterList.tsx
+++ b/src/app/championships/[cId]/ChampionshipRosterList.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import ConfirmingButton from "@/components/ConfirmingButton"
+import { TrashIcon } from "@heroicons/react/24/outline"
+import { useRouter } from "next/navigation"
+import { removeChampionshipRegistration } from "../championshipActions"
+
+export type ChampionshipRegistrationRow = {
+    id: string
+    name: string
+    membershipNo: string
+    competitorNumber: number
+    ageGroupName: string
+    categoryName: string
+    club: string
+    canRemove: boolean
+}
+
+function RemoveRegistrationButton({
+    championshipId,
+    registrationId,
+    canRemove,
+    readOnly,
+}: {
+    championshipId: string
+    registrationId: string
+    canRemove: boolean
+    readOnly: boolean
+}) {
+    const router = useRouter()
+
+    if (readOnly) {
+        return null
+    }
+
+    if (!canRemove) {
+        return <span className="text-xs text-base-content/50">Enrolled on a day — cannot remove</span>
+    }
+
+    return (
+        <ConfirmingButton
+            className="inline"
+            action={() =>
+                removeChampionshipRegistration(championshipId, registrationId).then(() => router.refresh())
+            }
+            baseButton={{
+                className: "btn-error btn-xs",
+                children: (
+                    <>
+                        <TrashIcon width={16} />
+                        Remove
+                    </>
+                ),
+            }}
+            confirmButton={{
+                className: "btn-warning btn-xs",
+                children: <>Confirm remove</>,
+            }}
+        />
+    )
+}
+
+export default function ChampionshipRosterList({
+    championshipId,
+    registrations,
+    readOnly = false,
+}: {
+    championshipId: string
+    registrations: ChampionshipRegistrationRow[]
+    readOnly?: boolean
+}) {
+    if (registrations.length === 0) {
+        return <p className="text-base-content/70">No competitors registered yet.</p>
+    }
+
+    return (
+        <ul className="flex flex-col gap-2 w-full max-w-3xl">
+            {registrations.map((registration) => (
+                <li key={registration.id} className="card bg-base-200 shadow-sm">
+                    <div className="card-body gap-2 py-3">
+                        <div className="flex flex-wrap items-start justify-between gap-2">
+                            <div className="flex flex-col gap-1">
+                                <div className="flex flex-wrap items-baseline gap-2">
+                                    <span className="badge badge-primary">#{registration.competitorNumber}</span>
+                                    <span className="font-medium">{registration.name}</span>
+                                </div>
+                                <p className="text-sm text-base-content/70">
+                                    {registration.membershipNo} · {registration.club}
+                                </p>
+                                <p className="text-sm text-base-content/70">
+                                    {registration.ageGroupName} · {registration.categoryName}
+                                </p>
+                            </div>
+                        <RemoveRegistrationButton
+                            championshipId={championshipId}
+                            registrationId={registration.id}
+                            canRemove={registration.canRemove}
+                            readOnly={readOnly}
+                        />
+                        </div>
+                    </div>
+                </li>
+            ))}
+        </ul>
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipRosterSection.tsx
+++ b/src/app/championships/[cId]/ChampionshipRosterSection.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import ParticipantCSVImport from "@/components/participants/ParticipantCSVImport"
+import type { CSVImportState } from "@/lib/participantCsvImport"
+import { useRouter } from "next/navigation"
+import { useCallback } from "react"
+import { importChampionshipRegistrationsCSV } from "./championshipCsvImportActions"
+import ChampionshipRosterList, { type ChampionshipRegistrationRow } from "./ChampionshipRosterList"
+import RegisterChampionshipCompetitorForm from "./RegisterChampionshipCompetitorForm"
+import { ErrorContextProvider } from "@/components/errors/ErrorContext"
+
+export default function ChampionshipRosterSection({
+    championshipId,
+    registrations,
+    readOnly = false,
+}: {
+    championshipId: string
+    registrations: ChampionshipRegistrationRow[]
+    readOnly?: boolean
+}) {
+    const router = useRouter()
+
+    const handleImportComplete = useCallback((result: CSVImportState) => {
+        if (result.success) {
+            router.refresh()
+        }
+    }, [router])
+
+    return (
+        <ErrorContextProvider>
+            <section className="mt-8">
+                <div className="flex flex-wrap items-start justify-between gap-3 mb-3">
+                    <h2 className="text-lg font-medium">Competitor roster</h2>
+                    {!readOnly ? (
+                        <ParticipantCSVImport
+                            drawerId={`championship-csv-import-${championshipId}`}
+                            entityId={championshipId}
+                            entityIdFieldName="championshipId"
+                            importAction={importChampionshipRegistrationsCSV}
+                            permalink={`/championships/${championshipId}`}
+                            title="Import Competitors"
+                            submitLabel="Import Competitors"
+                            onImportComplete={handleImportComplete}
+                        />
+                    ) : null}
+                </div>
+                {!readOnly ? <RegisterChampionshipCompetitorForm championshipId={championshipId} /> : null}
+                <div className={readOnly ? "" : "mt-4"}>
+                    <ChampionshipRosterList
+                        championshipId={championshipId}
+                        registrations={registrations}
+                        readOnly={readOnly}
+                    />
+                </div>
+            </section>
+        </ErrorContextProvider>
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipRoundsList.tsx
+++ b/src/app/championships/[cId]/ChampionshipRoundsList.tsx
@@ -36,13 +36,18 @@ function RemoveDayButton({
     championshipId,
     dayOrder,
     canRemove,
+    readOnly,
 }: {
     championshipId: string
     dayOrder: number
     canRemove: boolean
+    readOnly: boolean
 }) {
     const router = useRouter()
 
+    if (readOnly) {
+        return null
+    }
     if (!canRemove) {
         return <span className="text-xs text-base-content/50">Scores entered — cannot remove</span>
     }
@@ -71,9 +76,11 @@ function RemoveDayButton({
 export default function ChampionshipRoundsList({
     championshipId,
     rounds,
+    readOnly = false,
 }: {
     championshipId: string
     rounds: ChampionshipRoundRow[]
+    readOnly?: boolean
 }) {
     if (rounds.length === 0) {
         return <p className="text-base-content/70">No tournament days linked yet. Add the first day to begin.</p>
@@ -95,6 +102,7 @@ export default function ChampionshipRoundsList({
                                 championshipId={championshipId}
                                 dayOrder={round.dayOrder}
                                 canRemove={round.canRemove}
+                                readOnly={readOnly}
                             />
                         </div>
                         <DayTournamentLinks tournamentId={round.tournamentId} />

--- a/src/app/championships/[cId]/RegisterChampionshipCompetitorForm.tsx
+++ b/src/app/championships/[cId]/RegisterChampionshipCompetitorForm.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import ParticipantProfileFields from "@/components/participants/ParticipantProfileFields"
+import useErrorContext from "@/components/errors/ErrorContext"
+import { UserPlusIcon } from "@heroicons/react/24/solid"
+import Form from "next/form"
+import { useRouter } from "next/navigation"
+import { useActionState, useEffect, useRef } from "react"
+import { submitRegisterChampionshipCompetitorForm } from "./registerChampionshipCompetitorAction"
+import { initialRegisterChampionshipCompetitorFormState } from "./registerChampionshipCompetitorFormState"
+
+export default function RegisterChampionshipCompetitorForm({ championshipId }: { championshipId: string }) {
+    const router = useRouter()
+    const setError = useErrorContext()
+    const [formState, formAction, isPending] = useActionState(
+        submitRegisterChampionshipCompetitorForm,
+        initialRegisterChampionshipCompetitorFormState
+    )
+    const handledSuccessRef = useRef(false)
+    const errors = formState.errors ?? {}
+
+    useEffect(() => {
+        if (!formState.success || handledSuccessRef.current) {
+            return
+        }
+        handledSuccessRef.current = true
+        router.refresh()
+    }, [formState.success, router])
+
+    useEffect(() => {
+        const errorMessages = Object.values(errors)
+        if (errorMessages.length === 0) {
+            return
+        }
+        setError(errorMessages.join(", "))
+    }, [errors, setError])
+
+    return (
+        <div className="card w-full max-w-3xl bg-base-300 card-sm shadow-sm">
+            <Form
+                action={formAction}
+                className="card-body gap-4"
+                onSubmit={() => {
+                    handledSuccessRef.current = false
+                    setError(undefined)
+                }}
+            >
+                <input type="hidden" name="championshipId" value={championshipId} />
+                <ParticipantProfileFields errors={errors} data={formState.data} />
+                <div className="justify-end card-actions">
+                    <button type="submit" className="btn btn-success" disabled={isPending}>
+                        <UserPlusIcon width={20} />
+                        Register competitor
+                    </button>
+                </div>
+            </Form>
+        </div>
+    )
+}

--- a/src/app/championships/[cId]/__tests__/championshipCsvImportActions.test.ts
+++ b/src/app/championships/[cId]/__tests__/championshipCsvImportActions.test.ts
@@ -1,0 +1,134 @@
+import { GenderGroup } from "@/generated/prisma/enums"
+import { prismaMock } from "@/test/prismaSingleton"
+import { importChampionshipRegistrationsCSV } from "../championshipCsvImportActions"
+
+jest.mock("next/cache", () => ({
+    revalidatePath: jest.fn(),
+}))
+
+jest.mock("@/lib/championshipOrganizerSession", () => ({
+    assertChampionshipOrganizerClubs: jest.fn().mockResolvedValue(["ClubA"]),
+}))
+
+const initialState = {
+    success: false,
+    message: "",
+    importedCount: 0,
+    errors: [] as string[],
+}
+
+const validationSeed = () => {
+    prismaMock.ageGroup.findMany.mockResolvedValue([
+        { id: "S", name: "Senior" },
+        { id: "A", name: "Adult" },
+    ] as never)
+    prismaMock.equipmentCategory.findMany.mockResolvedValue([
+        { id: "BBC", name: "Barebow Compound" },
+        { id: "FSR", name: "Freestyle Recurve" },
+    ] as never)
+}
+
+const writableChampionship = () => {
+    prismaMock.championship.findFirst
+        .mockResolvedValueOnce({ id: "champ-1" } as never)
+        .mockResolvedValueOnce({ isArchive: false } as never)
+}
+
+describe("importChampionshipRegistrationsCSV", () => {
+    beforeEach(() => {
+        validationSeed()
+        writableChampionship()
+        prismaMock.$transaction.mockImplementation((callback) =>
+            typeof callback === "function" ? callback(prismaMock) : Promise.resolve(callback)
+        )
+        prismaMock.championshipRegistration.aggregate.mockResolvedValue({
+            _max: { competitorNumber: 2 },
+        } as never)
+        prismaMock.championshipRegistration.create.mockResolvedValue({ id: "reg-new" } as never)
+    })
+
+    it("returns error when championship id is missing", async () => {
+        const fd = new FormData()
+        fd.set("csvText", "John Doe,12345,M,S,BBC,Archery Club")
+
+        const result = await importChampionshipRegistrationsCSV(initialState, fd)
+
+        expect(result.success).toBe(false)
+        expect(result.errors).toContain("Championship ID not found")
+    })
+
+    it("returns parse errors for invalid rows", async () => {
+        const fd = new FormData()
+        fd.set("championshipId", "champ-1")
+        fd.set("csvText", "John Doe,12345,X,S,BBC,Archery Club")
+
+        const result = await importChampionshipRegistrationsCSV(initialState, fd)
+
+        expect(result.success).toBe(false)
+        expect(result.errors.some((error) => error.includes("Gender must be"))).toBe(true)
+        expect(prismaMock.$transaction).not.toHaveBeenCalled()
+    })
+
+    it("rejects rows with empty club", async () => {
+        const fd = new FormData()
+        fd.set("championshipId", "champ-1")
+        fd.set("csvText", "John Doe,12345,M,S,BBC,")
+
+        const result = await importChampionshipRegistrationsCSV(initialState, fd)
+
+        expect(result.success).toBe(false)
+        expect(result.errors).toContain("Row 1: Club is required")
+        expect(prismaMock.$transaction).not.toHaveBeenCalled()
+    })
+
+    it("imports valid rows with sequential competitor numbers", async () => {
+        const fd = new FormData()
+        fd.set("championshipId", "champ-1")
+        fd.set("csvText", `John Doe,12345,M,S,BBC,Archery Club
+Jane Smith,67890,F,A,FSR,Independent`)
+
+        const result = await importChampionshipRegistrationsCSV(initialState, fd)
+
+        expect(result).toEqual({
+            success: true,
+            message: "Successfully imported 2 competitors",
+            importedCount: 2,
+            errors: [],
+        })
+        expect(prismaMock.championshipRegistration.create).toHaveBeenNthCalledWith(1, {
+            data: {
+                championshipId: "champ-1",
+                name: "John Doe",
+                membershipNo: "12345",
+                ageGroupId: "S",
+                categoryId: "BBC",
+                club: "Archery Club",
+                genderGroup: GenderGroup.M,
+                competitorNumber: 3,
+            },
+        })
+        expect(prismaMock.championshipRegistration.create).toHaveBeenNthCalledWith(2, {
+            data: expect.objectContaining({
+                membershipNo: "67890",
+                competitorNumber: 4,
+            }),
+        })
+    })
+
+    it("returns duplicate membership error from database", async () => {
+        prismaMock.$transaction.mockRejectedValue({
+            code: "P2002",
+            meta: { target: ["championshipId", "membershipNo"] },
+            message: "Unique constraint failed",
+        })
+
+        const fd = new FormData()
+        fd.set("championshipId", "champ-1")
+        fd.set("csvText", "John Doe,12345,M,S,BBC,Archery Club")
+
+        const result = await importChampionshipRegistrationsCSV(initialState, fd)
+
+        expect(result.success).toBe(false)
+        expect(result.errors[0]).toContain("Duplicate entry")
+    })
+})

--- a/src/app/championships/[cId]/championshipCsvImportActions.ts
+++ b/src/app/championships/[cId]/championshipCsvImportActions.ts
@@ -1,0 +1,135 @@
+"use server"
+
+import { Prisma } from "@/generated/prisma/client"
+import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
+import {
+    CSVImportState,
+    fetchParticipantValidationMaps,
+    formatImportPrismaError,
+    parseErrorsToImportState,
+    parseParticipantCsv,
+} from "@/lib/participantCsvImport"
+import { prismaOrThrow } from "@/lib/prisma"
+import { revalidatePath } from "next/cache"
+import { assertChampionshipWritable } from "../championshipActions"
+
+function validateChampionshipClubRows(profiles: ParticipantProfileInput[]): CSVImportState | null {
+    const errors = profiles.flatMap((profile, index) =>
+        profile.club.trim() ? [] : [`Row ${index + 1}: Club is required`]
+    )
+
+    if (errors.length === 0) {
+        return null
+    }
+
+    return {
+        success: false,
+        message: `CSV parsing failed with ${errors.length} error(s)`,
+        importedCount: 0,
+        errors,
+    }
+}
+
+async function insertChampionshipRegistrations(
+    championshipId: string,
+    profiles: ParticipantProfileInput[]
+): Promise<number> {
+    await assertChampionshipWritable(championshipId)
+
+    await prismaOrThrow("import championship registrations").$transaction(async (tx) => {
+        const currentMax = await tx.championshipRegistration.aggregate({
+            where: { championshipId },
+            _max: { competitorNumber: true },
+        })
+
+        let nextCompetitorNumber = (currentMax._max.competitorNumber ?? 0) + 1
+
+        for (const profile of profiles) {
+            await tx.championshipRegistration.create({
+                data: {
+                    championshipId,
+                    name: profile.name.trim(),
+                    membershipNo: profile.membershipNo.trim(),
+                    ageGroupId: profile.ageGroupId,
+                    categoryId: profile.categoryId,
+                    club: profile.club.trim(),
+                    genderGroup: profile.genderGroup,
+                    competitorNumber: nextCompetitorNumber,
+                },
+            })
+            nextCompetitorNumber += 1
+        }
+    }, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    })
+
+    return profiles.length
+}
+
+export async function importChampionshipRegistrationsCSV(
+    _initialState: CSVImportState,
+    fd: FormData
+): Promise<CSVImportState> {
+    const championshipId = fd.get("championshipId")
+    const csvText = fd.get("csvText")
+
+    if (typeof championshipId !== "string" || !championshipId) {
+        return {
+            success: false,
+            message: "Championship ID is required",
+            importedCount: 0,
+            errors: ["Championship ID not found"],
+        }
+    }
+
+    if (typeof csvText !== "string" || !csvText) {
+        return {
+            success: false,
+            message: "CSV data is required",
+            importedCount: 0,
+            errors: ["CSV data not found"],
+        }
+    }
+
+    try {
+        const maps = await fetchParticipantValidationMaps()
+        const { profiles, errors: parseErrors } = await parseParticipantCsv(csvText, maps)
+
+        if (parseErrors.length > 0) {
+            return parseErrorsToImportState(parseErrors)
+        }
+
+        const clubErrors = validateChampionshipClubRows(profiles)
+        if (clubErrors) {
+            return clubErrors
+        }
+
+        if (profiles.length === 0) {
+            return {
+                success: false,
+                message: "No valid data found in CSV file",
+                importedCount: 0,
+                errors: ["CSV file appears to be empty or invalid"],
+            }
+        }
+
+        const count = await insertChampionshipRegistrations(championshipId, profiles)
+        revalidatePath(`/championships/${championshipId}`)
+
+        return {
+            success: true,
+            message: `Successfully imported ${count} competitors`,
+            importedCount: count,
+            errors: [],
+        }
+    } catch (error) {
+        console.error("Failed to import championship registrations CSV:", error)
+        const errorMessage = formatImportPrismaError(error)
+        return {
+            success: false,
+            message: `Import failed: ${errorMessage}`,
+            importedCount: 0,
+            errors: [errorMessage],
+        }
+    }
+}

--- a/src/app/championships/[cId]/page.tsx
+++ b/src/app/championships/[cId]/page.tsx
@@ -5,10 +5,15 @@ import {
 } from "@/lib/championshipOrganizerScope"
 import { auth } from "../../auth"
 import { notFound } from "next/navigation"
-import { getChampionshipForOrganizer } from "../championshipActions"
+import {
+    getChampionshipForOrganizer,
+    listChampionshipEnrolledMembershipNos,
+} from "../championshipActions"
 import { competitorsRegisteredLabel } from "../competitorsRegisteredLabel"
 import ChampionshipDaysSection from "./ChampionshipDaysSection"
 import ChampionshipNameEdit from "./ChampionshipNameEdit"
+import ChampionshipRosterSection from "./ChampionshipRosterSection"
+import type { ChampionshipRegistrationRow } from "./ChampionshipRosterList"
 
 export default async function ChampionshipDetailPage({ params }: { params: Promise<{ cId: string }> }) {
     const session = await auth()
@@ -25,6 +30,9 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
         notFound()
     }
 
+    const enrolledMembershipNos = await listChampionshipEnrolledMembershipNos(cId, clubs)
+    const enrolledSet = new Set(enrolledMembershipNos ?? [])
+
     const rounds = championship.rounds.map((round) => ({
         id: round.id,
         dayOrder: round.dayOrder,
@@ -34,11 +42,31 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
         canRemove: round.tournament._count.participantScores === 0,
     }))
 
+    const registrations: ChampionshipRegistrationRow[] = championship.registrations.map((registration) => ({
+        id: registration.id,
+        name: registration.name,
+        membershipNo: registration.membershipNo,
+        competitorNumber: registration.competitorNumber,
+        ageGroupName: registration.ageGroup.name,
+        categoryName: registration.category.name,
+        club: registration.club,
+        canRemove: !enrolledSet.has(registration.membershipNo),
+    }))
+
     return (
         <div className="w-full p-4">
             <div className="flex flex-wrap items-baseline justify-between gap-2 mb-6">
-                <ChampionshipNameEdit championshipId={championship.id} initialName={championship.name} />
-                <span className="badge badge-lg badge-info badge-outline">{championship.organizerClub}</span>
+                <ChampionshipNameEdit
+                    championshipId={championship.id}
+                    initialName={championship.name}
+                    readOnly={championship.isArchive}
+                />
+                <div className="flex flex-wrap gap-2">
+                    {championship.isArchive ? (
+                        <span className="badge badge-lg badge-warning">Archived</span>
+                    ) : null}
+                    <span className="badge badge-lg badge-info badge-outline">{championship.organizerClub}</span>
+                </div>
             </div>
             <p className="text-sm text-base-content/70 mb-2">
                 {competitorsRegisteredLabel(championship._count.registrations)}.
@@ -48,6 +76,12 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
                 championshipName={championship.name}
                 organizerClub={championship.organizerClub}
                 rounds={rounds}
+                readOnly={championship.isArchive}
+            />
+            <ChampionshipRosterSection
+                championshipId={championship.id}
+                registrations={registrations}
+                readOnly={championship.isArchive}
             />
         </div>
     )

--- a/src/app/championships/[cId]/registerChampionshipCompetitorAction.ts
+++ b/src/app/championships/[cId]/registerChampionshipCompetitorAction.ts
@@ -1,0 +1,54 @@
+"use server"
+
+import { normalizeFieldErrors } from "@/lib/normalizeFieldErrors"
+import { participantProfileSchema } from "@/lib/participantProfileSchema"
+import { z } from "zod"
+import { zu } from "zod_utilz"
+import { registerChampionshipParticipant } from "../championshipActions"
+import type { RegisterChampionshipCompetitorFormState } from "./registerChampionshipCompetitorFormState"
+
+const registerChampionshipCompetitorFormSchema = participantProfileSchema.extend({
+    championshipId: z.string().min(1),
+})
+
+function formDataToInput(formData: FormData) {
+    return {
+        championshipId: formData.get("championshipId"),
+        name: formData.get("name"),
+        membershipNo: formData.get("membershipNo"),
+        club: formData.get("club"),
+        ageGroupId: formData.get("ageGroupId"),
+        genderGroup: formData.get("genderGroup"),
+        categoryId: formData.get("categoryId"),
+    }
+}
+
+export async function submitRegisterChampionshipCompetitorForm(
+    _initialState: RegisterChampionshipCompetitorFormState,
+    formData: FormData
+): Promise<RegisterChampionshipCompetitorFormState> {
+    const formInput = formDataToInput(formData)
+    const parsed = zu.partialSafeParse(registerChampionshipCompetitorFormSchema, formInput)
+
+    if (!parsed.success || parsed.successType !== "full") {
+        return {
+            data: parsed.validData,
+            errors: normalizeFieldErrors(parsed.error?.flatten().fieldErrors),
+            success: false,
+        }
+    }
+
+    const input = registerChampionshipCompetitorFormSchema.parse(formInput)
+
+    try {
+        await registerChampionshipParticipant(input)
+        return { errors: {}, success: true }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to register competitor"
+        return {
+            data: input,
+            errors: { _form: message },
+            success: false,
+        }
+    }
+}

--- a/src/app/championships/[cId]/registerChampionshipCompetitorFormState.ts
+++ b/src/app/championships/[cId]/registerChampionshipCompetitorFormState.ts
@@ -1,0 +1,11 @@
+import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
+
+export type RegisterChampionshipCompetitorFormState = {
+    data?: Partial<ParticipantProfileInput>
+    errors: Record<string, string>
+    success?: boolean
+}
+
+export const initialRegisterChampionshipCompetitorFormState: RegisterChampionshipCompetitorFormState = {
+    errors: {},
+}

--- a/src/app/championships/__tests__/championshipActions.test.ts
+++ b/src/app/championships/__tests__/championshipActions.test.ts
@@ -5,10 +5,19 @@ import {
     createChampionship,
     getChampionshipForOrganizer,
     listChampionshipDayTournamentsForClubs,
+    listChampionshipEnrolledMembershipNos,
+    listMyChampionshipsForClubs,
     registerChampionshipParticipant,
+    archiveChampionship,
     removeChampionshipDay,
+    removeChampionshipRegistration,
+    unarchiveChampionship,
     updateChampionship,
 } from "../championshipActions"
+
+jest.mock("next/cache", () => ({
+    revalidatePath: jest.fn(),
+}))
 
 jest.mock("@/lib/championshipOrganizerSession", () => ({
     assertChampionshipOrganizerClubs: jest.fn().mockResolvedValue(["ClubA"]),
@@ -354,9 +363,23 @@ describe("addRoundTournament", () => {
     })
 })
 
+const registrationInput = {
+    championshipId: "champ-1",
+    name: "Alex Archer",
+    membershipNo: "M-001",
+    ageGroupId: "age-1",
+    categoryId: "cat-1",
+    club: "Club A",
+    genderGroup: "M" as const,
+}
+
 describe("registerChampionshipParticipant", () => {
     beforeEach(() => {
         prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1" } as never)
+        prismaMock.championshipRegistration.aggregate.mockResolvedValue({
+            _max: { competitorNumber: 0 },
+        } as never)
+        prismaMock.championshipRegistration.create.mockResolvedValue({ id: "reg-1" } as never)
     })
 
     it("retries on competitor number collisions and succeeds", async () => {
@@ -365,14 +388,19 @@ describe("registerChampionshipParticipant", () => {
                 code: "P2002",
                 meta: { target: ["championshipId", "competitorNumber"] },
             })
-            .mockResolvedValueOnce({ id: "reg-1" })
+            .mockImplementationOnce((callback) =>
+                typeof callback === "function" ? callback(prismaMock) : Promise.resolve({ id: "reg-1" })
+            )
 
-        await expect(
-            registerChampionshipParticipant({
+        await expect(registerChampionshipParticipant(registrationInput)).resolves.toEqual({ id: "reg-1" })
+        expect(prismaMock.championshipRegistration.create).toHaveBeenCalledWith({
+            data: expect.objectContaining({
                 championshipId: "champ-1",
                 membershipNo: "M-001",
-            })
-        ).resolves.toEqual({ id: "reg-1" })
+                name: "Alex Archer",
+                competitorNumber: 1,
+            }),
+        })
         expect(prismaMock.$transaction).toHaveBeenCalledTimes(2)
     })
 
@@ -382,22 +410,120 @@ describe("registerChampionshipParticipant", () => {
             meta: { target: ["championshipId", "membershipNo"] },
         })
 
-        await expect(
-            registerChampionshipParticipant({
-                championshipId: "champ-1",
-                membershipNo: "M-001",
-            })
-        ).rejects.toThrow("This membership number is already registered in this championship")
+        await expect(registerChampionshipParticipant(registrationInput)).rejects.toThrow(
+            "This membership number is already registered in this championship"
+        )
     })
 
     it("rethrows non-unique transaction failures", async () => {
         prismaMock.$transaction.mockRejectedValue(new Error("network"))
 
-        await expect(
-            registerChampionshipParticipant({
-                championshipId: "champ-1",
-                membershipNo: "M-001",
+        await expect(registerChampionshipParticipant(registrationInput)).rejects.toThrow("network")
+    })
+})
+
+describe("listChampionshipEnrolledMembershipNos", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1", rounds: [] } as never)
+    })
+
+    it("returns distinct membership numbers enrolled on championship days", async () => {
+        prismaMock.participant.findMany.mockResolvedValue([
+            { membershipNo: "M-001" },
+            { membershipNo: "M-002" },
+        ] as never)
+
+        await expect(listChampionshipEnrolledMembershipNos("champ-1", ["ClubA"])).resolves.toEqual([
+            "M-001",
+            "M-002",
+        ])
+    })
+
+    it("returns null when championship is not in scope", async () => {
+        prismaMock.championship.findFirst.mockResolvedValue(null)
+
+        await expect(listChampionshipEnrolledMembershipNos("champ-1", ["ClubA"])).resolves.toBeNull()
+        expect(prismaMock.participant.findMany).not.toHaveBeenCalled()
+    })
+})
+
+describe("removeChampionshipRegistration", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1" } as never)
+    })
+
+    it("removes registration when competitor is not enrolled on any day", async () => {
+        prismaMock.championshipRegistration.findFirst.mockResolvedValue({
+            id: "reg-1",
+            membershipNo: "M-001",
+        } as never)
+        prismaMock.participant.findFirst.mockResolvedValue(null)
+        prismaMock.championshipRegistration.delete.mockResolvedValue({ id: "reg-1" } as never)
+
+        await expect(removeChampionshipRegistration("champ-1", "reg-1")).resolves.toBeUndefined()
+        expect(prismaMock.championshipRegistration.delete).toHaveBeenCalledWith({
+            where: { id: "reg-1" },
+        })
+    })
+
+    it("throws when competitor is enrolled on a championship day", async () => {
+        prismaMock.championshipRegistration.findFirst.mockResolvedValue({
+            id: "reg-1",
+            membershipNo: "M-001",
+        } as never)
+        prismaMock.participant.findFirst.mockResolvedValue({ id: "part-1" } as never)
+
+        await expect(removeChampionshipRegistration("champ-1", "reg-1")).rejects.toThrow(
+            "Cannot remove a competitor enrolled on a championship day"
+        )
+        expect(prismaMock.championshipRegistration.delete).not.toHaveBeenCalled()
+    })
+
+    it("throws when registration is not found", async () => {
+        prismaMock.championshipRegistration.findFirst.mockResolvedValue(null)
+
+        await expect(removeChampionshipRegistration("champ-1", "reg-missing")).rejects.toThrow(
+            "Registration not found"
+        )
+    })
+})
+
+describe("archiveChampionship", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1", isArchive: false } as never)
+        prismaMock.championship.update.mockResolvedValue({ id: "champ-1", isArchive: true, rounds: [] } as never)
+    })
+
+    it("archives an authorized championship", async () => {
+        await expect(archiveChampionship("champ-1")).resolves.toMatchObject({ id: "champ-1", isArchive: true })
+        expect(prismaMock.championship.update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: "champ-1" },
+                data: { isArchive: true },
             })
-        ).rejects.toThrow("network")
+        )
+    })
+})
+
+describe("listMyChampionshipsForClubs", () => {
+    it("excludes archived championships by default", async () => {
+        prismaMock.championship.findMany.mockResolvedValue([] as never)
+
+        await listMyChampionshipsForClubs(["ClubA"], false)
+
+        expect(prismaMock.championship.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({ isArchive: false }),
+            })
+        )
+    })
+
+    it("includes archived championships when requested", async () => {
+        prismaMock.championship.findMany.mockResolvedValue([] as never)
+
+        await listMyChampionshipsForClubs(["ClubA"], true)
+
+        const call = prismaMock.championship.findMany.mock.calls[0][0]
+        expect(call.where.isArchive).toBeUndefined()
     })
 })

--- a/src/app/championships/championshipActions.ts
+++ b/src/app/championships/championshipActions.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { revalidatePath } from "next/cache"
 import { Prisma } from "@/generated/prisma/client"
 import { championshipDayTournamentName, nextChampionshipDayOrder } from "@/lib/championshipDayNaming"
 import { assertChampionshipOrganizerClubs, resolveChampionshipOrganizerClubs } from "@/lib/championshipOrganizerSession"
@@ -50,7 +51,12 @@ async function syncDayTournamentNamesForChampionship(
 
 export interface RegisterChampionshipParticipantInput {
     championshipId: string
+    name: string
     membershipNo: string
+    ageGroupId: string
+    categoryId: string
+    club: string
+    genderGroup: "F" | "M"
 }
 
 function isUniqueError(error: unknown): boolean {
@@ -80,6 +86,13 @@ const championshipShellInclude = {
             },
         },
         orderBy: { dayOrder: "asc" as const },
+    },
+    registrations: {
+        orderBy: { competitorNumber: "asc" as const },
+        include: {
+            ageGroup: true,
+            category: true,
+        },
     },
     _count: {
         select: { registrations: true },
@@ -127,6 +140,10 @@ export async function updateChampionship(championshipId: string, input: Champion
         throw new Error("Unauthorized")
     }
 
+    if (existing.isArchive) {
+        throw new Error("Championship is archived")
+    }
+
     if (input.name === undefined) {
         return prismaOrThrow("update championship").championship.update({
             where: { id: championshipId },
@@ -152,21 +169,27 @@ export async function updateChampionship(championshipId: string, input: Champion
     })
 }
 
-export async function listMyChampionships(): Promise<ChampionshipShellRow[] | null> {
+export async function listMyChampionships(includeArchive = false): Promise<ChampionshipShellRow[] | null> {
     const clubs = await resolveChampionshipOrganizerClubs()
     if (!clubs) {
         return null
     }
 
-    return listMyChampionshipsForClubs(clubs)
+    return listMyChampionshipsForClubs(clubs, includeArchive)
 }
 
-export async function listMyChampionshipsForClubs(clubs: string[]): Promise<ChampionshipShellRow[] | null> {
+export async function listMyChampionshipsForClubs(
+    clubs: string[],
+    includeArchive: boolean
+): Promise<ChampionshipShellRow[] | null> {
+    const isArchive: boolean | undefined = includeArchive ? undefined : false
+
     return prismaOrThrow("list championships").championship.findMany({
         where: {
             organizerClub: {
                 in: clubs,
             },
+            isArchive,
         },
         include: championshipShellInclude,
         orderBy: {
@@ -221,11 +244,26 @@ async function assertChampionshipAccessForId(championshipId: string): Promise<vo
     }
 }
 
+export async function assertChampionshipWritable(championshipId: string): Promise<void> {
+    await assertChampionshipAccessForId(championshipId)
+    const championship = await prismaOrThrow("get championship archive state").championship.findFirst({
+        where: { id: championshipId },
+        select: { isArchive: true },
+    })
+    if (championship?.isArchive) {
+        throw new Error("Championship is archived")
+    }
+}
+
 export async function addChampionshipDay(input: AddChampionshipDayInput) {
     const clubs = await assertChampionshipOrganizerClubs()
     const championship = await getChampionshipForOrganizer(input.championshipId, clubs)
     if (!championship) {
         throw new Error("Unauthorized")
+    }
+
+    if (championship.isArchive) {
+        throw new Error("Championship is archived")
     }
 
     const dayOrder = nextChampionshipDayOrder(championship.rounds)
@@ -303,6 +341,10 @@ export async function removeChampionshipDay(championshipId: string, dayOrder: nu
         throw new Error("Unauthorized")
     }
 
+    if (championship.isArchive) {
+        throw new Error("Championship is archived")
+    }
+
     const round = championship.rounds.find((item) => item.dayOrder === dayOrder)
     if (!round) {
         throw new Error("Championship day not found")
@@ -377,7 +419,7 @@ export async function reorderRounds(championshipId: string, orderedRoundIds: str
 }
 
 export async function registerChampionshipParticipant(input: RegisterChampionshipParticipantInput) {
-    await assertChampionshipAccessForId(input.championshipId)
+    await assertChampionshipWritable(input.championshipId)
 
     const maxRetries = 5
     let attempt = 0
@@ -395,12 +437,20 @@ export async function registerChampionshipParticipant(input: RegisterChampionshi
                 return tx.championshipRegistration.create({
                     data: {
                         championshipId: input.championshipId,
-                        membershipNo: input.membershipNo,
+                        membershipNo: input.membershipNo.trim(),
                         competitorNumber: nextCompetitorNumber,
+                        name: input.name.trim(),
+                        ageGroupId: input.ageGroupId,
+                        categoryId: input.categoryId,
+                        club: input.club.trim(),
+                        genderGroup: input.genderGroup,
                     },
                 })
             }, {
                 isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+            }).then((registration) => {
+                revalidatePath(`/championships/${input.championshipId}`)
+                return registration
             })
         } catch (error) {
             if (!isUniqueError(error)) {
@@ -422,4 +472,89 @@ export async function registerChampionshipParticipant(input: RegisterChampionshi
     }
 
     throw new Error("Unable to register championship participant")
+}
+
+export async function listChampionshipEnrolledMembershipNos(
+    championshipId: string,
+    organizerClubs: string[]
+): Promise<string[] | null> {
+    const championship = await getChampionshipForOrganizer(championshipId, organizerClubs)
+    if (!championship) {
+        return null
+    }
+
+    const participants = await prismaOrThrow("list championship enrolled membership numbers")
+        .participant.findMany({
+            where: {
+                tournament: {
+                    championshipRound: { championshipId },
+                },
+            },
+            select: { membershipNo: true },
+            distinct: ["membershipNo"],
+        })
+        .catch((error) => {
+            logAndReturnNull("Failed to list enrolled competitors", error)
+            return null
+        })
+
+    if (!participants) {
+        return null
+    }
+
+    return participants.map((row) => row.membershipNo)
+}
+
+export async function removeChampionshipRegistration(championshipId: string, registrationId: string) {
+    await assertChampionshipWritable(championshipId)
+
+    const registration = await prismaOrThrow("find championship registration").championshipRegistration.findFirst({
+        where: { id: registrationId, championshipId },
+    })
+
+    if (!registration) {
+        throw new Error("Registration not found")
+    }
+
+    const enrolled = await prismaOrThrow("check championship enrollment").participant.findFirst({
+        where: {
+            membershipNo: registration.membershipNo,
+            tournament: {
+                championshipRound: { championshipId },
+            },
+        },
+        select: { id: true },
+    })
+
+    if (enrolled) {
+        throw new Error("Cannot remove a competitor enrolled on a championship day")
+    }
+
+    await prismaOrThrow("remove championship registration").championshipRegistration.delete({
+        where: { id: registrationId },
+    })
+
+    revalidatePath(`/championships/${championshipId}`)
+}
+
+async function setChampionshipArchiveState(championshipId: string, isArchive: boolean) {
+    await assertChampionshipAccessForId(championshipId)
+
+    const championship = await prismaOrThrow("set championship archive state").championship.update({
+        where: { id: championshipId },
+        data: { isArchive },
+        include: championshipShellInclude,
+    })
+
+    revalidatePath("/championships")
+    revalidatePath(`/championships/${championshipId}`)
+    return championship
+}
+
+export async function archiveChampionship(championshipId: string) {
+    return setChampionshipArchiveState(championshipId, true)
+}
+
+export async function unarchiveChampionship(championshipId: string) {
+    return setChampionshipArchiveState(championshipId, false)
 }

--- a/src/app/tournaments/[tId]/AddParticipantForm.tsx
+++ b/src/app/tournaments/[tId]/AddParticipantForm.tsx
@@ -61,7 +61,7 @@ export default function AddParticipantForm({ tId, participant, onCancel }: AddPa
                 <div className="flex-1 flex gap-1 flex-wrap items-stretch">
                     <input type="text" name="name" className={`sm:w-2/5 input input-xs md:input-sm flex-grow ${formState.errors?.name ? 'input-error' : 'input-secondary'}`} placeholder="Archer's Name" defaultValue={defaultName} />
                     <input type="text" name="membershipNo" className={`w-fit input input-xs md:input-sm flex-grow ${formState.errors?.membershipNo ? 'input-error' : 'input-secondary'}`} placeholder="Membership No." defaultValue={defaultMembershipNo} />
-                    <input type="text" name="club" className="sm:w-2/5 input input-xs md:input-sm input-secondary flex-grow" placeholder="Archer's Club" defaultValue={defaultClub} />
+                    <input type="text" name="club" className={`sm:w-2/5 input input-xs md:input-sm flex-grow ${formState.errors?.club ? 'input-error' : 'input-secondary'}`} placeholder="Archer's Club" defaultValue={defaultClub} required />
                     <AgeDivisionSelect name="ageGroupId" className="min-w-fit select select-xs md:select-sm select-secondary w-2/5 md:w-1/3 flex-1" defaultValue={defaultAgeGroupId} />
                     <GenderSelect name="genderGroup" className="min-w-fit select select-xs md:select-sm select-secondary w-2/5 md:w-1/3 flex-1" defaultValue={defaultGenderGroup} />
                     <EquipmentCategorySelect name="categoryId" className="min-w-fit select select-xs md:select-sm select-secondary md:w-1/3 flex-1 " defaultValue={defaultCategoryId} />

--- a/src/app/tournaments/[tId]/components/CSVImport.tsx
+++ b/src/app/tournaments/[tId]/components/CSVImport.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { DocumentArrowUpIcon } from "@heroicons/react/24/outline"
 import useTournamentContext from "../TournamentContext"
-import CSVUploadForm from "./CSVUploadForm"
+import ParticipantCSVImport from "@/components/participants/ParticipantCSVImport"
+import { importParticipantsCSV } from "../csvImportActions"
 
 interface CSVImportProps {
     onImportComplete: (result: { success: boolean; message: string; importedCount: number; errors: string[] }) => void
@@ -11,33 +11,22 @@ interface CSVImportProps {
 export default function CSVImport({ onImportComplete }: CSVImportProps) {
     const tournament = useTournamentContext()
 
+    if (!tournament) {
+        return null
+    }
+
+    const tournamentId = tournament.getTournamentId()
+
     return (
-        <div className="drawer drawer-end">
-            <input id="csv-import-drawer" type="checkbox" className="drawer-toggle" />
-
-            <div className="drawer-content">
-                <label className="btn drawer-btn text-xs bg-primary color-primary w-32" htmlFor="csv-import-drawer">
-                    <DocumentArrowUpIcon className="w-6 h-6" />
-                    Import CSV
-                </label>
-            </div>
-
-            <div className="drawer-side">
-                <label htmlFor="csv-import-drawer" className="drawer-overlay"></label>
-                <div className="min-h-full w-80 bg-base-200 p-4">
-                    <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-lg font-semibold">Import Participants</h3>
-                        <label htmlFor="csv-import-drawer" className="btn btn-sm btn-circle btn-ghost">✕</label>
-                    </div>
-
-                    {tournament && (
-                        <CSVUploadForm
-                            tournamentId={tournament.getTournamentId()}
-                            onImportComplete={onImportComplete}
-                        />
-                    )}
-                </div>
-            </div>
-        </div>
+        <ParticipantCSVImport
+            drawerId="csv-import-drawer"
+            entityId={tournamentId}
+            entityIdFieldName="tId"
+            importAction={importParticipantsCSV}
+            permalink={`/tournaments/${tournamentId}`}
+            title="Import Participants"
+            submitLabel="Import Participants"
+            onImportComplete={onImportComplete}
+        />
     )
 }

--- a/src/app/tournaments/[tId]/components/CSVUploadForm.tsx
+++ b/src/app/tournaments/[tId]/components/CSVUploadForm.tsx
@@ -1,184 +1,22 @@
 "use client"
 
-import { DocumentArrowUpIcon } from "@heroicons/react/24/outline"
-import { useActionState, useEffect, useRef, useState } from "react"
-import { CSVImportState, importParticipantsCSV } from "../csvImportActions"
+import ParticipantCSVUploadForm from "@/components/participants/ParticipantCSVUploadForm"
+import { importParticipantsCSV } from "../csvImportActions"
 
 interface CSVUploadFormProps {
     tournamentId: string
     onImportComplete?: (result: { success: boolean; message: string; importedCount: number; errors: string[] }) => void
 }
 
-const initialState: CSVImportState = {
-    success: false,
-    message: "",
-    importedCount: 0,
-    errors: []
-}
-
-export default function CSVUploadForm({
-    tournamentId,
-    onImportComplete
-}: CSVUploadFormProps) {
-    const [csvText, setCsvText] = useState("")
-    const [dragOver, setDragOver] = useState(false)
-    const [fileUploadError, setFileUploadError] = useState<string | null>(null)
-    const lastProcessedStateRef = useRef<CSVImportState | null>(null)
-
-    const [importState, importAction, isPending] = useActionState(
-        importParticipantsCSV,
-        initialState,
-        `/tournaments/${tournamentId}`
-    )
-
-    const formatImportError = (): string | null => {
-        if (importState.errors.length === 0) {
-            return null
-        }
-        if (importState.errors.length === 1) {
-            return importState.errors[0]
-        }
-        return `${importState.message}\n\n${importState.errors.map((e, i) => `${i + 1}. ${e}`).join('\n')}`
-    }
-
-    const formatSuccessMessage = (): string | null => {
-        if (importState.success && importState.message) {
-            return importState.message
-        }
-        return null
-    }
-
-    const error = formatImportError() || fileUploadError
-    const successMessage = formatSuccessMessage()
-
-    // Handle import state changes with useEffect to avoid render-time state updates
-    // Use ref to prevent calling onImportComplete multiple times for the same state
-    useEffect(() => {
-        if (!onImportComplete) {
-            return
-        }
-
-        const hasChanged =
-            lastProcessedStateRef.current?.success !== importState.success ||
-            lastProcessedStateRef.current?.importedCount !== importState.importedCount ||
-            lastProcessedStateRef.current?.errors.length !== importState.errors.length
-
-        if (hasChanged && (importState.success || importState.errors.length > 0)) {
-            lastProcessedStateRef.current = importState
-            onImportComplete(importState)
-        }
-    }, [importState, onImportComplete])
-
-    const handleFileUpload = async (file: File) => {
-        try {
-            const text = await file.text()
-            setFileUploadError(null) // Clear any previous errors
-            setCsvText(text)
-        } catch (error) {
-            console.error("Failed to read CSV file:", error)
-            setFileUploadError(error instanceof Error ? error.message : "Unknown error")
-        }
-    }
-
-    const handleFileInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0]
-        if (file) {
-            handleFileUpload(file)
-        }
-    }
-
-    const handleDrop = (event: React.DragEvent) => {
-        event.preventDefault()
-        setDragOver(false)
-
-        const file = event.dataTransfer.files[0]
-        if (file && file.type === 'text/csv') {
-            handleFileUpload(file)
-        }
-    }
-
-    const handleDragOver = (event: React.DragEvent) => {
-        event.preventDefault()
-        setDragOver(true)
-    }
-
-    const handleDragLeave = (event: React.DragEvent) => {
-        event.preventDefault()
-        setDragOver(false)
-    }
-
-    const handleSubmit = (formData: FormData) => {
-        if (csvText) {
-            formData.set('csvText', csvText)
-            lastProcessedStateRef.current = null // Reset ref when starting new import
-            importAction(formData)
-        }
-    }
-
+export default function CSVUploadForm({ tournamentId, onImportComplete }: CSVUploadFormProps) {
     return (
-        <form action={handleSubmit}>
-            <input type="hidden" name="tId" value={tournamentId} />
-
-            <div
-                className={`border-2 border-dashed rounded-lg p-4 text-center transition-colors ${dragOver
-                    ? 'border-primary bg-primary/10'
-                    : 'border-base-300 hover:border-primary/50'
-                    }`}
-                onDrop={handleDrop}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-            >
-                <DocumentArrowUpIcon className="w-8 h-8 mx-auto mb-3 text-base-content/50" />
-
-                <div className="mb-3">
-                    <p className="font-medium mb-1">Drop CSV file here</p>
-                    <p className="text-sm text-base-content/70">or click to browse</p>
-                </div>
-
-                <input
-                    type="file"
-                    accept=".csv"
-                    onChange={handleFileInput}
-                    disabled={isPending}
-                    className="hidden"
-                    id="csv-upload"
-                />
-
-                <label
-                    htmlFor="csv-upload"
-                    className={`btn btn-sm ${isPending ? 'btn-disabled' : 'btn-primary'}`}
-                >
-                    {isPending ? 'Processing...' : 'Choose File'}
-                </label>
-
-                {csvText && (
-                    <div className="mt-3">
-                        <button
-                            type="submit"
-                            disabled={isPending}
-                            className="btn btn-success btn-sm"
-                        >
-                            {isPending ? 'Importing...' : 'Import Participants'}
-                        </button>
-                    </div>
-                )}
-
-                <div className="mt-3 text-xs text-base-content/60">
-                    <p>Required columns:</p>
-                    <p>1. Full Name, 2. Membership Number, 3. Gender (F/M), 4. Age Group ID, 5. Equipment Category ID, 6. Club Name</p>
-                </div>
-                {successMessage && (
-                    <div className="alert alert-success mt-3">
-                        {successMessage}
-                    </div>
-                )}
-                {!!error && (
-                    <div className="alert alert-error mt-3">
-                        <div className="whitespace-pre-line">{error}</div>
-                    </div>
-                )}
-            </div>
-        </form>
+        <ParticipantCSVUploadForm
+            entityId={tournamentId}
+            entityIdFieldName="tId"
+            importAction={importParticipantsCSV}
+            permalink={`/tournaments/${tournamentId}`}
+            submitLabel="Import Participants"
+            onImportComplete={onImportComplete}
+        />
     )
 }
-

--- a/src/app/tournaments/[tId]/csvImportActions.ts
+++ b/src/app/tournaments/[tId]/csvImportActions.ts
@@ -1,248 +1,51 @@
 "use server"
 
 import { Participant } from "@/generated/prisma/client"
-import { GenderGroup } from "@/generated/prisma/enums"
 import { prismaOrThrow } from "@/lib/prisma"
+import {
+    CSVImportState,
+    fetchParticipantValidationMaps,
+    formatImportPrismaError,
+    parseErrorsToImportState,
+    parseParticipantCsv,
+    type ValidationMaps,
+} from "@/lib/participantCsvImport"
 import { revalidatePath } from "next/cache"
-import Papa from "papaparse"
 
-export interface CSVImportState {
-    success: boolean
-    message: string
-    importedCount: number
-    errors: string[]
-}
+export type { CSVImportState, ValidationMaps }
 
-interface ParseError {
-    row: number
-    message: string
-}
-
-interface ParseResult {
-    participants: Omit<Participant, 'id'>[]
-    errors: ParseError[]
-}
-
-export interface ValidationMaps {
-    ageGroups: Set<string>
-    categories: Set<string>
-    ageGroupMap: Map<string, string> // id -> name
-    categoryMap: Map<string, string> // id -> name
-}
-
-type ColumnTransformer<T> = (value: string, rowNumber: number, maps: ValidationMaps) => { value: T; error?: string }
-
-const createRequiredStringTransformer = (fieldName: string): ColumnTransformer<string> => {
-    return (value: string, rowNumber: number) => {
-        const trimmed = value.trim()
-        if (!trimmed) {
-            return { value: "", error: `Row ${rowNumber}: ${fieldName} is required` }
-        }
-        return { value: trimmed }
-    }
-}
-
-const createGenderTransformer = (): ColumnTransformer<GenderGroup> => {
-    return (value: string, rowNumber: number) => {
-        const trimmed = value.trim().toUpperCase()
-
-        if (trimmed === 'M' || trimmed === 'MALE') {
-            return { value: GenderGroup.M }
-        }
-
-        if (trimmed === 'F' || trimmed === 'FEMALE') {
-            return { value: GenderGroup.F }
-        }
-
-        return { value: 'M' as GenderGroup, error: `Row ${rowNumber}: Gender must be 'F', 'M', 'female', or 'male', got '${value}'` }
-    }
-}
-
-const createAgeGroupTransformer = (): ColumnTransformer<string> => {
-    return (value: string, rowNumber: number, maps: ValidationMaps) => {
-        const trimmed = value.trim()
-        if (!trimmed) {
-            return { value: "", error: `Row ${rowNumber}: Age group ID is required` }
-        }
-
-        // First check if it's a valid ID
-        if (maps.ageGroups.has(trimmed)) {
-            return { value: trimmed }
-        }
-
-        // Then check if it matches a name (case-insensitive)
-        const normalizedInput = trimmed.toLowerCase()
-        for (const [id, name] of maps.ageGroupMap.entries()) {
-            if (name.toLowerCase() === normalizedInput) {
-                return { value: id }
-            }
-        }
-
-        return { value: trimmed, error: `Row ${rowNumber}: Age group '${trimmed}' not found` }
-    }
-}
-
-const createCategoryTransformer = (): ColumnTransformer<string> => {
-    return (value: string, rowNumber: number, maps: ValidationMaps) => {
-        const trimmed = value.trim()
-        if (!trimmed) {
-            return { value: "", error: `Row ${rowNumber}: Equipment category ID is required` }
-        }
-
-        // First check if it's a valid ID
-        if (maps.categories.has(trimmed)) {
-            return { value: trimmed }
-        }
-
-        // Then check if it matches a name (case-insensitive)
-        const normalizedInput = trimmed.toLowerCase()
-        for (const [id, name] of maps.categoryMap.entries()) {
-            if (name.toLowerCase() === normalizedInput) {
-                return { value: id }
-            }
-        }
-
-        return { value: trimmed, error: `Row ${rowNumber}: Equipment category '${trimmed}' not found` }
-    }
-}
-
-const createOptionalStringTransformer = (): ColumnTransformer<string | null> => {
-    return (value: string) => {
-        const trimmed = value.trim()
-        return { value: trimmed || null }
-    }
-}
-
-function createColumnTransformers(): ColumnTransformer<unknown>[] {
-    return [
-        createRequiredStringTransformer("Full name"),
-        createRequiredStringTransformer("Membership number"),
-        createGenderTransformer(),
-        createAgeGroupTransformer(),
-        createCategoryTransformer(),
-        createOptionalStringTransformer(),
-    ]
-}
-
-function processRow(
-    row: string[],
-    rowNumber: number,
-    tournamentId: string,
-    maps: ValidationMaps,
-    columnTransformers: ColumnTransformer<unknown>[]
-): { participant?: Omit<Participant, 'id'>; errors: ParseError[] } {
-    if (row.length < columnTransformers.length) {
-        return {
-            errors: [{
-                row: rowNumber,
-                message: `Row ${rowNumber}: Expected ${columnTransformers.length} columns, found ${row.length}`
-            }]
-        }
-    }
-
-    const results = columnTransformers.map((transformer, index) =>
-        transformer(row[index], rowNumber, maps) as { value: unknown; error?: string }
-    )
-
-    const rowErrors = results
-        .filter(r => r.error)
-        .map(r => ({ row: rowNumber, message: r.error! }))
-
-    if (rowErrors.length > 0) {
-        return { errors: rowErrors }
-    }
+export async function parseCSV(csvText: string, tournamentId: string, maps: ValidationMaps) {
+    const { profiles, errors } = await parseParticipantCsv(csvText, maps)
 
     return {
-        participant: {
+        participants: profiles.map((profile) => ({
             tournamentId,
-            name: results[0].value as string,
-            membershipNo: results[1].value as string,
+            name: profile.name,
+            membershipNo: profile.membershipNo,
             competitorNumber: null,
-            genderGroup: results[2].value as GenderGroup,
-            ageGroupId: results[3].value as string,
-            categoryId: results[4].value as string,
-            club: results[5].value as string | null,
-            checkedIn: false
-        },
-        errors: []
+            genderGroup: profile.genderGroup,
+            ageGroupId: profile.ageGroupId,
+            categoryId: profile.categoryId,
+            club: profile.club.trim() || null,
+            checkedIn: false,
+        })) satisfies Omit<Participant, "id">[],
+        errors,
     }
 }
 
-export async function parseCSV(csvText: string, tournamentId: string, maps: ValidationMaps): Promise<ParseResult> {
-    const participants: Omit<Participant, 'id'>[] = []
-    const errors: ParseError[] = []
-    let rowNumber = 0
-    const columnTransformers = createColumnTransformers()
-
-    Papa.parse<string[]>(csvText, {
-        skipEmptyLines: true,
-        header: false,
-        step: (result) => {
-            rowNumber++
-            const { participant, errors: rowErrors } = processRow(result.data, rowNumber, tournamentId, maps, columnTransformers)
-            errors.push(...rowErrors)
-            if (participant) {
-                participants.push(participant)
-            }
-        },
-        complete: (results) => {
-            if (results.errors.length > 0) {
-                errors.push(...results.errors.map(e => ({
-                    row: e.row !== undefined ? e.row + 1 : 0,
-                    message: `CSV parsing error: ${e.message}`
-                })))
-            }
-        },
-        error: (error: Error) => {
-            errors.push({ row: 0, message: `CSV parsing error: ${error.message}` })
-        }
-    })
-
-    return { participants, errors }
-}
-
-async function fetchValidationMaps(): Promise<ValidationMaps> {
-    const prisma = prismaOrThrow("fetch validation maps")
-
-    const [ageGroups, categories] = await Promise.all([
-        prisma.ageGroup.findMany({ select: { id: true, name: true } }),
-        prisma.equipmentCategory.findMany({ select: { id: true, name: true } })
-    ])
-
-    const ageGroupMap = new Map<string, string>()
-    const categoryMap = new Map<string, string>()
-
-    ageGroups.forEach(ag => {
-        ageGroupMap.set(ag.id, ag.name)
-    })
-
-    categories.forEach(cat => {
-        categoryMap.set(cat.id, cat.name)
-    })
-
-    return {
-        ageGroups: new Set(ageGroups.map(ag => ag.id)),
-        categories: new Set(categories.map(cat => cat.id)),
-        ageGroupMap,
-        categoryMap
-    }
-}
-
-async function insertParticipants(
-    participants: Omit<Participant, 'id'>[]
-): Promise<number> {
+async function insertParticipants(participants: Omit<Participant, "id">[]): Promise<number> {
     const prisma = prismaOrThrow("insert participants")
 
     await prisma.participant.createMany({
-        data: participants
+        data: participants,
     })
 
     return participants.length
 }
 
 function validateFormData(fd: FormData): { valid: boolean; tournamentId?: string; csvText?: string; error?: CSVImportState } {
-    const tournamentId = fd.get('tId') as string
-    const csvText = fd.get('csvText') as string
+    const tournamentId = fd.get("tId") as string
+    const csvText = fd.get("csvText") as string
 
     if (!tournamentId) {
         return {
@@ -251,8 +54,8 @@ function validateFormData(fd: FormData): { valid: boolean; tournamentId?: string
                 success: false,
                 message: "Tournament ID is required",
                 importedCount: 0,
-                errors: ["Tournament ID not found"]
-            }
+                errors: ["Tournament ID not found"],
+            },
         }
     }
 
@@ -263,66 +66,16 @@ function validateFormData(fd: FormData): { valid: boolean; tournamentId?: string
                 success: false,
                 message: "CSV data is required",
                 importedCount: 0,
-                errors: ["CSV data not found"]
-            }
+                errors: ["CSV data not found"],
+            },
         }
     }
 
     return { valid: true, tournamentId, csvText }
 }
 
-function handleParseErrors(parseErrors: ParseError[]): CSVImportState | null {
-    if (parseErrors.length > 0) {
-        return {
-            success: false,
-            message: `CSV parsing failed with ${parseErrors.length} error(s)`,
-            importedCount: 0,
-            errors: parseErrors.map(e => e.message)
-        }
-    }
-    return null
-}
-
-function handleEmptyParticipants(): CSVImportState {
-    return {
-        success: false,
-        message: "No valid data found in CSV file",
-        importedCount: 0,
-        errors: ["CSV file appears to be empty or invalid"]
-    }
-}
-
-function formatPrismaError(error: unknown): string {
-    if (error && typeof error === 'object' && 'code' in error) {
-        const prismaError = error as { code: string; meta?: { target?: string[] }; message: string }
-
-        // Handle unique constraint violations
-        if (prismaError.code === 'P2002') {
-            const field = prismaError.meta?.target?.join(', ') || 'field'
-            return `Duplicate entry: A participant with same value of (${field}) already exists in this tournament`
-        }
-
-        // Handle foreign key constraint violations
-        if (prismaError.code === 'P2003') {
-            return `Invalid reference: The referenced record does not exist`
-        }
-
-        // Return the Prisma message if available
-        if (prismaError.message) {
-            return prismaError.message
-        }
-    }
-
-    // Fallback to standard error handling
-    if (error instanceof Error) {
-        return error.message
-    }
-
-    return 'Unknown error occurred during import'
-}
-
 export async function importParticipantsCSV(
-    initialState: CSVImportState,
+    _initialState: CSVImportState,
     fd: FormData
 ): Promise<CSVImportState> {
     try {
@@ -331,46 +84,53 @@ export async function importParticipantsCSV(
             return formValidation.error!
         }
 
-        const maps = await fetchValidationMaps()
-        const { participants, errors: parseErrors } = await parseCSV(formValidation.csvText!, formValidation.tournamentId!, maps)
+        const maps = await fetchParticipantValidationMaps()
+        const { participants, errors: parseErrors } = await parseCSV(
+            formValidation.csvText!,
+            formValidation.tournamentId!,
+            maps
+        )
 
-        const parseErrorResult = handleParseErrors(parseErrors)
-        if (parseErrorResult) {
-            return parseErrorResult
+        if (parseErrors.length > 0) {
+            return parseErrorsToImportState(parseErrors)
         }
 
         if (participants.length === 0) {
-            return handleEmptyParticipants()
+            return {
+                success: false,
+                message: "No valid data found in CSV file",
+                importedCount: 0,
+                errors: ["CSV file appears to be empty or invalid"],
+            }
         }
 
         try {
             const count = await insertParticipants(participants)
-            revalidatePath(`/tournaments/${formValidation.tournamentId!}`, 'page')
+            revalidatePath(`/tournaments/${formValidation.tournamentId!}`, "page")
             return {
                 success: true,
                 message: `Successfully imported ${count} participants`,
                 importedCount: count,
-                errors: []
+                errors: [],
             }
         } catch (error) {
             console.error("Failed to insert participants:", error)
-            const errorMessage = formatPrismaError(error)
+            const errorMessage = formatImportPrismaError(error)
             return {
                 success: false,
                 message: `Import failed: ${errorMessage}`,
                 importedCount: 0,
-                errors: [errorMessage]
+                errors: [errorMessage],
             }
         }
-
     } catch (error) {
         console.error("Failed to import participants CSV:", error)
-        const errorMessage = formatPrismaError(error)
+        const errorMessage = formatImportPrismaError(error)
         return {
             success: false,
             message: `Import failed: ${errorMessage}`,
             importedCount: 0,
-            errors: [errorMessage]
+            errors: [errorMessage],
         }
     }
 }

--- a/src/app/tournaments/[tId]/participantActions.ts
+++ b/src/app/tournaments/[tId]/participantActions.ts
@@ -1,22 +1,14 @@
 "use server"
 
+import { participantProfileSchema } from "@/lib/participantProfileSchema"
 import { prismaOrThrow } from "@/lib/prisma"
 import { revalidatePath } from "next/cache"
 import { redirect, RedirectType } from "next/navigation"
 import { z } from "zod"
-import { zu } from 'zod_utilz'
+import { zu } from "zod_utilz"
 
-const participantSubmitSchema = z.object({
+const participantSubmitSchema = participantProfileSchema.extend({
     tournamentId: z.string().nonempty(),
-    name: z.string().min(3, "Name must be at least 3 characters long"),
-    membershipNo: z.string().nonempty("Membership number is required"),
-    genderGroup: z.union([
-        z.literal("F"),
-        z.literal("M"),
-    ]),
-    ageGroupId: z.string().nonempty("Age Division must be selected"),
-    categoryId: z.string().nonempty("Equipment Category must be selected"),
-    club: z.string(),
     checkedIn: z.boolean().default(false),
 })
 

--- a/src/components/participants/ParticipantCSVImport.tsx
+++ b/src/components/participants/ParticipantCSVImport.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { DocumentArrowUpIcon } from "@heroicons/react/24/outline"
+import type { CSVImportState } from "@/lib/participantCsvImport"
+import ParticipantCSVUploadForm from "./ParticipantCSVUploadForm"
+
+export default function ParticipantCSVImport({
+    drawerId,
+    entityId,
+    entityIdFieldName,
+    importAction,
+    permalink,
+    title,
+    submitLabel,
+    onImportComplete,
+}: {
+    drawerId: string
+    entityId: string
+    entityIdFieldName: string
+    importAction: (initialState: CSVImportState, formData: FormData) => Promise<CSVImportState>
+    permalink?: string
+    title: string
+    submitLabel: string
+    onImportComplete?: (result: CSVImportState) => void
+}) {
+    return (
+        <div className="drawer drawer-end">
+            <input id={drawerId} type="checkbox" className="drawer-toggle" />
+
+            <div className="drawer-content">
+                <label className="btn drawer-btn text-xs bg-primary color-primary w-32" htmlFor={drawerId}>
+                    <DocumentArrowUpIcon className="w-6 h-6" />
+                    Import CSV
+                </label>
+            </div>
+
+            <div className="drawer-side">
+                <label htmlFor={drawerId} className="drawer-overlay"></label>
+                <div className="min-h-full w-80 bg-base-200 p-4">
+                    <div className="flex items-center justify-between mb-4">
+                        <h3 className="text-lg font-semibold">{title}</h3>
+                        <label htmlFor={drawerId} className="btn btn-sm btn-circle btn-ghost">✕</label>
+                    </div>
+
+                    <ParticipantCSVUploadForm
+                        entityId={entityId}
+                        entityIdFieldName={entityIdFieldName}
+                        importAction={importAction}
+                        permalink={permalink}
+                        submitLabel={submitLabel}
+                        onImportComplete={onImportComplete}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/participants/ParticipantCSVUploadForm.tsx
+++ b/src/components/participants/ParticipantCSVUploadForm.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { DocumentArrowUpIcon } from "@heroicons/react/24/outline"
+import { useActionState, useEffect, useRef, useState } from "react"
+import type { CSVImportState } from "@/lib/participantCsvImport"
+
+const participantCsvColumnHelp =
+    "1. Full Name, 2. Membership Number, 3. Gender (F/M), 4. Age Group ID, 5. Equipment Category ID, 6. Club Name"
+
+const initialState: CSVImportState = {
+    success: false,
+    message: "",
+    importedCount: 0,
+    errors: []
+}
+
+export default function ParticipantCSVUploadForm({
+    entityId,
+    entityIdFieldName,
+    importAction,
+    permalink,
+    submitLabel,
+    onImportComplete,
+}: {
+    entityId: string
+    entityIdFieldName: string
+    importAction: (initialState: CSVImportState, formData: FormData) => Promise<CSVImportState>
+    permalink?: string
+    submitLabel: string
+    onImportComplete?: (result: CSVImportState) => void
+}) {
+    const [csvText, setCsvText] = useState("")
+    const [dragOver, setDragOver] = useState(false)
+    const [fileUploadError, setFileUploadError] = useState<string | null>(null)
+    const lastProcessedStateRef = useRef<CSVImportState | null>(null)
+
+    const [importState, importFormAction, isPending] = useActionState(
+        importAction,
+        initialState,
+        permalink
+    )
+
+    const formatImportError = (): string | null => {
+        if (importState.errors.length === 0) {
+            return null
+        }
+        if (importState.errors.length === 1) {
+            return importState.errors[0]
+        }
+        return `${importState.message}\n\n${importState.errors.map((e, i) => `${i + 1}. ${e}`).join('\n')}`
+    }
+
+    const formatSuccessMessage = (): string | null => {
+        if (importState.success && importState.message) {
+            return importState.message
+        }
+        return null
+    }
+
+    const error = formatImportError() || fileUploadError
+    const successMessage = formatSuccessMessage()
+
+    // Handle import state changes with useEffect to avoid render-time state updates
+    // Use ref to prevent calling onImportComplete multiple times for the same state
+    useEffect(() => {
+        if (!onImportComplete) {
+            return
+        }
+
+        const hasChanged =
+            lastProcessedStateRef.current?.success !== importState.success ||
+            lastProcessedStateRef.current?.importedCount !== importState.importedCount ||
+            lastProcessedStateRef.current?.errors.length !== importState.errors.length
+
+        if (hasChanged && (importState.success || importState.errors.length > 0)) {
+            lastProcessedStateRef.current = importState
+            onImportComplete(importState)
+        }
+    }, [importState, onImportComplete])
+
+    const handleFileUpload = async (file: File) => {
+        try {
+            const text = await file.text()
+            setFileUploadError(null) // Clear any previous errors
+            setCsvText(text)
+        } catch (error) {
+            console.error("Failed to read CSV file:", error)
+            setFileUploadError(error instanceof Error ? error.message : "Unknown error")
+        }
+    }
+
+    const handleFileInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+        if (file) {
+            handleFileUpload(file)
+        }
+    }
+
+    const handleDrop = (event: React.DragEvent) => {
+        event.preventDefault()
+        setDragOver(false)
+
+        const file = event.dataTransfer.files[0]
+        if (file && file.type === 'text/csv') {
+            handleFileUpload(file)
+        }
+    }
+
+    const handleDragOver = (event: React.DragEvent) => {
+        event.preventDefault()
+        setDragOver(true)
+    }
+
+    const handleDragLeave = (event: React.DragEvent) => {
+        event.preventDefault()
+        setDragOver(false)
+    }
+
+    const handleSubmit = (formData: FormData) => {
+        if (csvText) {
+            formData.set('csvText', csvText)
+            lastProcessedStateRef.current = null // Reset ref when starting new import
+            importFormAction(formData)
+        }
+    }
+
+    return (
+        <form action={handleSubmit}>
+            <input type="hidden" name={entityIdFieldName} value={entityId} />
+
+            <div
+                className={`border-2 border-dashed rounded-lg p-4 text-center transition-colors ${dragOver
+                    ? 'border-primary bg-primary/10'
+                    : 'border-base-300 hover:border-primary/50'
+                    }`}
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+            >
+                <DocumentArrowUpIcon className="w-8 h-8 mx-auto mb-3 text-base-content/50" />
+
+                <div className="mb-3">
+                    <p className="font-medium mb-1">Drop CSV file here</p>
+                    <p className="text-sm text-base-content/70">or click to browse</p>
+                </div>
+
+                <input
+                    type="file"
+                    accept=".csv"
+                    onChange={handleFileInput}
+                    disabled={isPending}
+                    className="hidden"
+                    id={`csv-upload-${entityIdFieldName}`}
+                />
+
+                <label
+                    htmlFor={`csv-upload-${entityIdFieldName}`}
+                    className={`btn btn-sm ${isPending ? 'btn-disabled' : 'btn-primary'}`}
+                >
+                    {isPending ? 'Processing...' : 'Choose File'}
+                </label>
+
+                {csvText && (
+                    <div className="mt-3">
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="btn btn-success btn-sm"
+                        >
+                            {isPending ? 'Importing...' : submitLabel}
+                        </button>
+                    </div>
+                )}
+
+                <div className="mt-3 text-xs text-base-content/60">
+                    <p>Required columns:</p>
+                    <p>{participantCsvColumnHelp}</p>
+                </div>
+                {successMessage && (
+                    <div className="alert alert-success mt-3">
+                        {successMessage}
+                    </div>
+                )}
+                {!!error && (
+                    <div className="alert alert-error mt-3">
+                        <div className="whitespace-pre-line">{error}</div>
+                    </div>
+                )}
+            </div>
+        </form>
+    )
+}
+

--- a/src/components/participants/ParticipantProfileFields.tsx
+++ b/src/components/participants/ParticipantProfileFields.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import AgeDivisionSelect from "@/app/tournaments/[tId]/components/AgeDivisionSelect"
+import EquipmentCategorySelect from "@/app/tournaments/[tId]/components/EquipmentCategorySelect"
+import GenderSelect from "@/app/tournaments/[tId]/components/GenderSelect"
+import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
+
+function fieldClass(hasError: boolean, baseClass: string): string {
+    return hasError ? `${baseClass} input-error` : baseClass
+}
+
+export default function ParticipantProfileFields({
+    errors,
+    data,
+}: {
+    errors: Record<string, string>
+    data?: Partial<ParticipantProfileInput>
+}) {
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap gap-3">
+                <label className="form-control flex-1 min-w-48">
+                    <span className="label-text">Archer&apos;s name</span>
+                    <input
+                        type="text"
+                        name="name"
+                        className={fieldClass(!!errors.name, "input input-bordered w-full")}
+                        placeholder="Archer's name"
+                        defaultValue={data?.name ?? ""}
+                        required
+                    />
+                </label>
+                <label className="form-control flex-1 min-w-40">
+                    <span className="label-text">Membership number</span>
+                    <input
+                        type="text"
+                        name="membershipNo"
+                        className={fieldClass(!!errors.membershipNo, "input input-bordered w-full")}
+                        placeholder="Membership no."
+                        defaultValue={data?.membershipNo ?? ""}
+                        required
+                    />
+                </label>
+                <label className="form-control flex-1 min-w-40">
+                    <span className="label-text">Club</span>
+                    <input
+                        type="text"
+                        name="club"
+                        className={fieldClass(!!errors.club, "input input-bordered w-full")}
+                        placeholder="Club"
+                        defaultValue={data?.club ?? ""}
+                        required
+                    />
+                </label>
+            </div>
+            <div className="flex flex-wrap gap-3">
+                <label className="form-control flex-1 min-w-40">
+                    <span className="label-text">Age division</span>
+                    <AgeDivisionSelect
+                        name="ageGroupId"
+                        className={fieldClass(!!errors.ageGroupId, "select select-bordered w-full")}
+                        defaultValue={data?.ageGroupId ?? ""}
+                    />
+                </label>
+                <label className="form-control flex-1 min-w-32">
+                    <span className="label-text">Gender</span>
+                    <GenderSelect
+                        name="genderGroup"
+                        className={fieldClass(!!errors.genderGroup, "select select-bordered w-full")}
+                        defaultValue={data?.genderGroup}
+                    />
+                </label>
+                <label className="form-control flex-1 min-w-40">
+                    <span className="label-text">Equipment category</span>
+                    <EquipmentCategorySelect
+                        name="categoryId"
+                        className={fieldClass(!!errors.categoryId, "select select-bordered w-full")}
+                        defaultValue={data?.categoryId ?? ""}
+                    />
+                </label>
+            </div>
+        </div>
+    )
+}

--- a/src/lib/normalizeFieldErrors.ts
+++ b/src/lib/normalizeFieldErrors.ts
@@ -1,0 +1,13 @@
+export function normalizeFieldErrors(
+    fieldErrors: Record<string, string[] | undefined> | undefined
+): Record<string, string> {
+    if (!fieldErrors) {
+        return {}
+    }
+
+    return Object.fromEntries(
+        Object.entries(fieldErrors)
+            .filter((entry): entry is [string, string[]] => !!entry[1]?.length)
+            .map(([field, messages]) => [field, messages[0]])
+    )
+}

--- a/src/lib/participantCsvImport.ts
+++ b/src/lib/participantCsvImport.ts
@@ -1,0 +1,255 @@
+import { GenderGroup } from "@/generated/prisma/enums"
+import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
+import { prismaOrThrow } from "@/lib/prisma"
+import Papa from "papaparse"
+
+export interface CSVImportState {
+    success: boolean
+    message: string
+    importedCount: number
+    errors: string[]
+}
+
+interface ParseError {
+    row: number
+    message: string
+}
+
+export interface ValidationMaps {
+    ageGroups: Set<string>
+    categories: Set<string>
+    ageGroupMap: Map<string, string>
+    categoryMap: Map<string, string>
+}
+
+type ColumnTransformer<T> = (value: string, rowNumber: number, maps: ValidationMaps) => { value: T; error?: string }
+
+const createRequiredStringTransformer = (fieldName: string): ColumnTransformer<string> => {
+    return (value: string, rowNumber: number) => {
+        const trimmed = value.trim()
+        if (!trimmed) {
+            return { value: "", error: `Row ${rowNumber}: ${fieldName} is required` }
+        }
+        return { value: trimmed }
+    }
+}
+
+const createGenderTransformer = (): ColumnTransformer<GenderGroup> => {
+    return (value: string, rowNumber: number) => {
+        const trimmed = value.trim().toUpperCase()
+
+        if (trimmed === "M" || trimmed === "MALE") {
+            return { value: GenderGroup.M }
+        }
+
+        if (trimmed === "F" || trimmed === "FEMALE") {
+            return { value: GenderGroup.F }
+        }
+
+        return {
+            value: GenderGroup.M,
+            error: `Row ${rowNumber}: Gender must be 'F', 'M', 'female', or 'male', got '${value}'`,
+        }
+    }
+}
+
+const createAgeGroupTransformer = (): ColumnTransformer<string> => {
+    return (value: string, rowNumber: number, maps: ValidationMaps) => {
+        const trimmed = value.trim()
+        if (!trimmed) {
+            return { value: "", error: `Row ${rowNumber}: Age group ID is required` }
+        }
+
+        if (maps.ageGroups.has(trimmed)) {
+            return { value: trimmed }
+        }
+
+        const normalizedInput = trimmed.toLowerCase()
+        for (const [id, name] of maps.ageGroupMap.entries()) {
+            if (name.toLowerCase() === normalizedInput) {
+                return { value: id }
+            }
+        }
+
+        return { value: trimmed, error: `Row ${rowNumber}: Age group '${trimmed}' not found` }
+    }
+}
+
+const createCategoryTransformer = (): ColumnTransformer<string> => {
+    return (value: string, rowNumber: number, maps: ValidationMaps) => {
+        const trimmed = value.trim()
+        if (!trimmed) {
+            return { value: "", error: `Row ${rowNumber}: Equipment category ID is required` }
+        }
+
+        if (maps.categories.has(trimmed)) {
+            return { value: trimmed }
+        }
+
+        const normalizedInput = trimmed.toLowerCase()
+        for (const [id, name] of maps.categoryMap.entries()) {
+            if (name.toLowerCase() === normalizedInput) {
+                return { value: id }
+            }
+        }
+
+        return { value: trimmed, error: `Row ${rowNumber}: Equipment category '${trimmed}' not found` }
+    }
+}
+
+const createOptionalStringTransformer = (): ColumnTransformer<string> => {
+    return (value: string) => {
+        return { value: value.trim() }
+    }
+}
+
+function createColumnTransformers(): ColumnTransformer<unknown>[] {
+    return [
+        createRequiredStringTransformer("Full name"),
+        createRequiredStringTransformer("Membership number"),
+        createGenderTransformer(),
+        createAgeGroupTransformer(),
+        createCategoryTransformer(),
+        createOptionalStringTransformer(),
+    ]
+}
+
+function processRow(
+    row: string[],
+    rowNumber: number,
+    maps: ValidationMaps,
+    columnTransformers: ColumnTransformer<unknown>[]
+): { profile?: ParticipantProfileInput; errors: ParseError[] } {
+    if (row.length < columnTransformers.length) {
+        return {
+            errors: [{
+                row: rowNumber,
+                message: `Row ${rowNumber}: Expected ${columnTransformers.length} columns, found ${row.length}`,
+            }],
+        }
+    }
+
+    const results = columnTransformers.map((transformer, index) =>
+        transformer(row[index], rowNumber, maps) as { value: unknown; error?: string }
+    )
+
+    const rowErrors = results
+        .filter((result) => result.error)
+        .map((result) => ({ row: rowNumber, message: result.error! }))
+
+    if (rowErrors.length > 0) {
+        return { errors: rowErrors }
+    }
+
+    return {
+        profile: {
+            name: results[0].value as string,
+            membershipNo: results[1].value as string,
+            genderGroup: results[2].value as "F" | "M",
+            ageGroupId: results[3].value as string,
+            categoryId: results[4].value as string,
+            club: results[5].value as string,
+        },
+        errors: [],
+    }
+}
+
+export async function parseParticipantCsv(
+    csvText: string,
+    maps: ValidationMaps
+): Promise<{ profiles: ParticipantProfileInput[]; errors: ParseError[] }> {
+    const profiles: ParticipantProfileInput[] = []
+    const errors: ParseError[] = []
+    let rowNumber = 0
+    const columnTransformers = createColumnTransformers()
+
+    Papa.parse<string[]>(csvText, {
+        skipEmptyLines: true,
+        header: false,
+        step: (result) => {
+            rowNumber++
+            const { profile, errors: rowErrors } = processRow(result.data, rowNumber, maps, columnTransformers)
+            errors.push(...rowErrors)
+            if (profile) {
+                profiles.push(profile)
+            }
+        },
+        complete: (results) => {
+            if (results.errors.length > 0) {
+                errors.push(...results.errors.map((error) => ({
+                    row: error.row !== undefined ? error.row + 1 : 0,
+                    message: `CSV parsing error: ${error.message}`,
+                })))
+            }
+        },
+        error: (error: Error) => {
+            errors.push({ row: 0, message: `CSV parsing error: ${error.message}` })
+        },
+    })
+
+    return { profiles, errors }
+}
+
+export async function fetchParticipantValidationMaps(): Promise<ValidationMaps> {
+    const prisma = prismaOrThrow("fetch validation maps")
+
+    const [ageGroups, categories] = await Promise.all([
+        prisma.ageGroup.findMany({ select: { id: true, name: true } }),
+        prisma.equipmentCategory.findMany({ select: { id: true, name: true } }),
+    ])
+
+    const ageGroupMap = new Map<string, string>()
+    const categoryMap = new Map<string, string>()
+
+    ageGroups.forEach((ageGroup) => {
+        ageGroupMap.set(ageGroup.id, ageGroup.name)
+    })
+
+    categories.forEach((category) => {
+        categoryMap.set(category.id, category.name)
+    })
+
+    return {
+        ageGroups: new Set(ageGroups.map((ageGroup) => ageGroup.id)),
+        categories: new Set(categories.map((category) => category.id)),
+        ageGroupMap,
+        categoryMap,
+    }
+}
+
+export function formatImportPrismaError(error: unknown): string {
+    if (error && typeof error === "object" && "code" in error) {
+        const prismaError = error as { code: string; meta?: { target?: string[] }; message: string }
+
+        if (prismaError.code === "P2002") {
+            const field = prismaError.meta?.target?.join(", ") || "field"
+            return `Duplicate entry: A row with the same value of (${field}) already exists`
+        }
+
+        if (prismaError.code === "P2003") {
+            return "Invalid reference: The referenced record does not exist"
+        }
+
+        if (prismaError.message) {
+            return prismaError.message
+        }
+    }
+
+    if (error instanceof Error) {
+        return error.message
+    }
+
+    return "Unknown error occurred during import"
+}
+
+export function parseErrorsToImportState(parseErrors: ParseError[]): CSVImportState {
+    return {
+        success: false,
+        message: `CSV parsing failed with ${parseErrors.length} error(s)`,
+        importedCount: 0,
+        errors: parseErrors.map((error) => error.message),
+    }
+}
+
+export const participantCsvColumnHelp =
+    "1. Full Name, 2. Membership Number, 3. Gender (F/M), 4. Age Group ID, 5. Equipment Category ID, 6. Club Name"

--- a/src/lib/participantProfileSchema.ts
+++ b/src/lib/participantProfileSchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const participantProfileSchema = z.object({
+    name: z.string().trim().min(3, "Name must be at least 3 characters long"),
+    membershipNo: z.string().trim().min(1, "Membership number is required"),
+    genderGroup: z.enum(["F", "M"], { message: "Gender must be selected" }),
+    ageGroupId: z.string().min(1, "Age division must be selected"),
+    categoryId: z.string().min(1, "Equipment category must be selected"),
+    club: z.string().trim().min(1, "Club is required"),
+})
+
+export type ParticipantProfileInput = z.infer<typeof participantProfileSchema>


### PR DESCRIPTION
## Summary
- Add full-profile championship competitor registration (name, membership, gender, age group, category, club) with roster list and remove support.
- Support bulk CSV import for championship competitors, reusing shared participant CSV components also used by tournament day imports.
- Add championship archive/unarchive and read-only behavior when archived; require club on registration.

## Test plan
- [ ] Register a competitor manually on a championship detail page and confirm roster display
- [ ] Import competitors via CSV and verify sequential competitor numbers and roster refresh
- [ ] Confirm empty club rows are rejected on championship CSV import
- [ ] Archive a championship and verify roster/day mutations and CSV import are blocked
- [ ] Confirm tournament CSV import still works after shared component refactor
- [ ] Run `npm test` and `npm run build`


Made with [Cursor](https://cursor.com)