### PR TITLE
M8: Enroll championship competitors on days

### DIFF
--- a/docs/architecture/ADR-0001-championships-multi-day.md
+++ b/docs/architecture/ADR-0001-championships-multi-day.md
@@ -216,7 +216,7 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - Remove registration only when not enrolled on any day (document cascade in runbook).
 - **UI test:** register two competitors with full profiles → see names, numbers, and divisions → remove one not enrolled on any day.
 
-### M8 — Enroll competitors into days
+### M8 — Enroll competitors into days ✓
 - Day enrollment actions: create/update `Participant` on the day tournament by copying all fields from `ChampionshipRegistration` (see enrollment rules).
 - Per day: show enrolled vs registered-not-enrolled; single/bulk enroll (no profile form at enroll unless registration is edited separately).
 - Unenroll from a day without removing championship registration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-comp",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/championships/[cId]/ChampionshipRosterDayCheckbox.tsx
+++ b/src/app/championships/[cId]/ChampionshipRosterDayCheckbox.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import useErrorContext from "@/components/errors/ErrorContext"
+import { useRouter } from "next/navigation"
+import { useTransition } from "react"
+import {
+    enrollChampionshipCompetitorsOnDay,
+    unenrollChampionshipCompetitorFromDay,
+} from "../championshipActions"
+
+export default function ChampionshipRosterDayCheckbox({
+    championshipId,
+    dayOrder,
+    membershipNo,
+    isEnrolled,
+    readOnly,
+}: {
+    championshipId: string
+    dayOrder: number
+    membershipNo: string
+    isEnrolled: boolean
+    readOnly: boolean
+}) {
+    const router = useRouter()
+    const setError = useErrorContext()
+    const [isPending, startTransition] = useTransition()
+
+    const handleToggle = (checked: boolean) => {
+        startTransition(() => {
+            const action = checked
+                ? enrollChampionshipCompetitorsOnDay(championshipId, dayOrder, [membershipNo])
+                : unenrollChampionshipCompetitorFromDay(championshipId, dayOrder, membershipNo)
+
+            action
+                .then(() => router.refresh())
+                .catch((error) => {
+                    setError(error instanceof Error ? error.message : "Unable to update day enrollment")
+                })
+        })
+    }
+
+    return (
+        <input
+            type="checkbox"
+            className="checkbox checkbox-xs"
+            checked={isEnrolled}
+            disabled={readOnly || isPending}
+            aria-label={`Day ${dayOrder}`}
+            title={`Day ${dayOrder}`}
+            onChange={(event) => handleToggle(event.target.checked)}
+        />
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipRosterDayEnrollAllButton.tsx
+++ b/src/app/championships/[cId]/ChampionshipRosterDayEnrollAllButton.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import useErrorContext from "@/components/errors/ErrorContext"
+import { useRouter } from "next/navigation"
+import { useTransition } from "react"
+import { enrollChampionshipCompetitorsOnDay } from "../championshipActions"
+
+export default function ChampionshipRosterDayEnrollAllButton({
+    championshipId,
+    dayOrder,
+    membershipNos,
+    readOnly,
+}: {
+    championshipId: string
+    dayOrder: number
+    membershipNos: string[]
+    readOnly: boolean
+}) {
+    const router = useRouter()
+    const setError = useErrorContext()
+    const [isPending, startTransition] = useTransition()
+
+    if (readOnly || membershipNos.length === 0) {
+        return null
+    }
+
+    const handleEnrollAll = () => {
+        startTransition(() => {
+            enrollChampionshipCompetitorsOnDay(championshipId, dayOrder, membershipNos)
+                .then(() => router.refresh())
+                .catch((error) => {
+                    setError(error instanceof Error ? error.message : "Unable to enroll all competitors")
+                })
+        })
+    }
+
+    return (
+        <button
+            type="button"
+            className="btn btn-primary btn-xs px-1 min-h-0 h-auto font-normal"
+            disabled={isPending}
+            title={`Enroll all competitors on day ${dayOrder}`}
+            onClick={handleEnrollAll}
+        >
+            All
+        </button>
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipRosterEnrollAllDaysButton.tsx
+++ b/src/app/championships/[cId]/ChampionshipRosterEnrollAllDaysButton.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import useErrorContext from "@/components/errors/ErrorContext"
+import { useRouter } from "next/navigation"
+import { useTransition } from "react"
+import { enrollChampionshipCompetitorsOnDay } from "../championshipActions"
+import type { ChampionshipRosterDayColumn } from "./ChampionshipRosterList"
+
+export default function ChampionshipRosterEnrollAllDaysButton({
+    championshipId,
+    days,
+    membershipNos,
+    readOnly,
+}: {
+    championshipId: string
+    days: ChampionshipRosterDayColumn[]
+    membershipNos: string[]
+    readOnly: boolean
+}) {
+    const router = useRouter()
+    const setError = useErrorContext()
+    const [isPending, startTransition] = useTransition()
+
+    if (readOnly || days.length === 0 || membershipNos.length === 0) {
+        return null
+    }
+
+    const handleEnrollAllDays = () => {
+        startTransition(async () => {
+            try {
+                for (const day of days) {
+                    await enrollChampionshipCompetitorsOnDay(championshipId, day.dayOrder, membershipNos)
+                }
+                router.refresh()
+            } catch (error) {
+                setError(error instanceof Error ? error.message : "Unable to enroll all competitors")
+            }
+        })
+    }
+
+    return (
+        <button
+            type="button"
+            className="btn btn-outline btn-sm"
+            disabled={isPending}
+            onClick={handleEnrollAllDays}
+        >
+            Enroll all on all days
+        </button>
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipRosterList.tsx
+++ b/src/app/championships/[cId]/ChampionshipRosterList.tsx
@@ -1,19 +1,76 @@
 "use client"
 
 import ConfirmingButton from "@/components/ConfirmingButton"
-import { TrashIcon } from "@heroicons/react/24/outline"
+import { InformationCircleIcon, PencilIcon, TrashIcon } from "@heroicons/react/24/outline"
 import { useRouter } from "next/navigation"
 import { removeChampionshipRegistration } from "../championshipActions"
+import ChampionshipRosterDayCheckbox from "./ChampionshipRosterDayCheckbox"
+import ChampionshipRosterDayEnrollAllButton from "./ChampionshipRosterDayEnrollAllButton"
+import ChampionshipRosterEnrollAllDaysButton from "./ChampionshipRosterEnrollAllDaysButton"
+import { championshipDetailContentClass } from "./championshipDetailLayout"
 
 export type ChampionshipRegistrationRow = {
     id: string
     name: string
     membershipNo: string
     competitorNumber: number
+    ageGroupId: string
+    categoryId: string
+    genderGroup: "F" | "M"
     ageGroupName: string
     categoryName: string
     club: string
     canRemove: boolean
+}
+
+export type ChampionshipRosterDayColumn = {
+    dayOrder: number
+    label: string
+}
+
+function EditRegistrationButton({
+    readOnly,
+    onEdit,
+}: {
+    readOnly: boolean
+    onEdit: () => void
+}) {
+    if (readOnly) {
+        return null
+    }
+
+    return (
+        <button type="button" className="btn btn-info btn-xs" onClick={onEdit}>
+            <PencilIcon width={16} />
+            Edit
+        </button>
+    )
+}
+
+function RosterRowActions({
+    championshipId,
+    registration,
+    canRemove,
+    readOnly,
+    onEdit,
+}: {
+    championshipId: string
+    registration: ChampionshipRegistrationRow
+    canRemove: boolean
+    readOnly: boolean
+    onEdit: () => void
+}) {
+    return (
+        <div className="flex flex-wrap justify-end gap-1">
+            <EditRegistrationButton readOnly={readOnly} onEdit={onEdit} />
+            <RemoveRegistrationButton
+                championshipId={championshipId}
+                registrationId={registration.id}
+                canRemove={canRemove}
+                readOnly={readOnly}
+            />
+        </div>
+    )
 }
 
 function RemoveRegistrationButton({
@@ -34,7 +91,7 @@ function RemoveRegistrationButton({
     }
 
     if (!canRemove) {
-        return <span className="text-xs text-base-content/50">Enrolled on a day — cannot remove</span>
+        return <span className="text-xs text-base-content/50">Enrolled — cannot remove</span>
     }
 
     return (
@@ -60,47 +117,189 @@ function RemoveRegistrationButton({
     )
 }
 
+function RosterEnrollmentHeader({
+    championshipId,
+    days,
+    membershipNos,
+    readOnly,
+}: {
+    championshipId: string
+    days: ChampionshipRosterDayColumn[]
+    membershipNos: string[]
+    readOnly: boolean
+}) {
+    return (
+        <tr className="text-xs text-base-content/70">
+            <th className="font-normal">Competitor</th>
+            {days.map((day) => (
+                <th key={day.dayOrder} className="font-normal text-center min-w-12" title={day.label}>
+                    <div className="flex flex-col items-center gap-0.5">
+                        <span>D{day.dayOrder}</span>
+                        <ChampionshipRosterDayEnrollAllButton
+                            championshipId={championshipId}
+                            dayOrder={day.dayOrder}
+                            membershipNos={membershipNos}
+                            readOnly={readOnly}
+                        />
+                    </div>
+                </th>
+            ))}
+            <th className="font-normal text-right">Actions</th>
+        </tr>
+    )
+}
+
+function RosterEnrollmentRow({
+    championshipId,
+    registration,
+    days,
+    enrolledDayOrders,
+    readOnly,
+    onEditRegistration,
+}: {
+    championshipId: string
+    registration: ChampionshipRegistrationRow
+    days: ChampionshipRosterDayColumn[]
+    enrolledDayOrders: Set<number>
+    readOnly: boolean
+    onEditRegistration: (registration: ChampionshipRegistrationRow) => void
+}) {
+    return (
+        <tr className="align-top">
+            <td>
+                <div className="flex flex-col gap-1 py-1">
+                    <div className="flex flex-wrap items-baseline gap-2">
+                        <span className="badge badge-primary badge-sm">#{registration.competitorNumber}</span>
+                        <span className="font-medium">{registration.name}</span>
+                    </div>
+                    <p className="text-sm text-base-content/70">
+                        {registration.membershipNo} · {registration.club}
+                    </p>
+                    <p className="text-sm text-base-content/70">
+                        {registration.ageGroupName} · {registration.categoryName}
+                    </p>
+                </div>
+            </td>
+            {days.map((day) => (
+                <td key={day.dayOrder} className="text-center">
+                    <ChampionshipRosterDayCheckbox
+                        championshipId={championshipId}
+                        dayOrder={day.dayOrder}
+                        membershipNo={registration.membershipNo}
+                        isEnrolled={enrolledDayOrders.has(day.dayOrder)}
+                        readOnly={readOnly}
+                    />
+                </td>
+            ))}
+            <td className="text-right">
+                <RosterRowActions
+                    championshipId={championshipId}
+                    registration={registration}
+                    canRemove={registration.canRemove}
+                    readOnly={readOnly}
+                    onEdit={() => onEditRegistration(registration)}
+                />
+            </td>
+        </tr>
+    )
+}
+
 export default function ChampionshipRosterList({
     championshipId,
     registrations,
+    days,
+    enrollmentByMembership,
     readOnly = false,
+    onEditRegistration,
 }: {
     championshipId: string
     registrations: ChampionshipRegistrationRow[]
+    days: ChampionshipRosterDayColumn[]
+    enrollmentByMembership: Record<string, number[]>
     readOnly?: boolean
+    onEditRegistration?: (registration: ChampionshipRegistrationRow) => void
 }) {
     if (registrations.length === 0) {
         return <p className="text-base-content/70">No competitors registered yet.</p>
     }
 
-    return (
-        <ul className="flex flex-col gap-2 w-full max-w-3xl">
-            {registrations.map((registration) => (
-                <li key={registration.id} className="card bg-base-200 shadow-sm">
-                    <div className="card-body gap-2 py-3">
-                        <div className="flex flex-wrap items-start justify-between gap-2">
-                            <div className="flex flex-col gap-1">
-                                <div className="flex flex-wrap items-baseline gap-2">
-                                    <span className="badge badge-primary">#{registration.competitorNumber}</span>
-                                    <span className="font-medium">{registration.name}</span>
+    if (days.length === 0) {
+        return (
+            <ul className={`flex flex-col gap-2 ${championshipDetailContentClass}`}>
+                {registrations.map((registration) => (
+                    <li key={registration.id} className="card bg-base-200 shadow-sm">
+                        <div className="card-body gap-2 py-3">
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                                <div className="flex flex-col gap-1">
+                                    <div className="flex flex-wrap items-baseline gap-2">
+                                        <span className="badge badge-primary">#{registration.competitorNumber}</span>
+                                        <span className="font-medium">{registration.name}</span>
+                                    </div>
+                                    <p className="text-sm text-base-content/70">
+                                        {registration.membershipNo} · {registration.club}
+                                    </p>
+                                    <p className="text-sm text-base-content/70">
+                                        {registration.ageGroupName} · {registration.categoryName}
+                                    </p>
                                 </div>
-                                <p className="text-sm text-base-content/70">
-                                    {registration.membershipNo} · {registration.club}
-                                </p>
-                                <p className="text-sm text-base-content/70">
-                                    {registration.ageGroupName} · {registration.categoryName}
-                                </p>
+                                <RosterRowActions
+                                    championshipId={championshipId}
+                                    registration={registration}
+                                    canRemove={registration.canRemove}
+                                    readOnly={readOnly}
+                                    onEdit={() => onEditRegistration?.(registration)}
+                                />
                             </div>
-                        <RemoveRegistrationButton
-                            championshipId={championshipId}
-                            registrationId={registration.id}
-                            canRemove={registration.canRemove}
-                            readOnly={readOnly}
-                        />
                         </div>
+                    </li>
+                ))}
+            </ul>
+        )
+    }
+
+    const membershipNos = registrations.map((registration) => registration.membershipNo)
+
+    return (
+        <div className={`overflow-x-auto ${championshipDetailContentClass}`}>
+            {!readOnly ? (
+                <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+                    <div role="note" className="alert alert-info alert-soft py-2 flex-1 min-w-0">
+                        <InformationCircleIcon className="w-5 h-5 shrink-0" />
+                        <span className="text-sm">
+                            Use All under a day column to enroll the full roster on that day, or use the checkboxes per competitor.
+                        </span>
                     </div>
-                </li>
-            ))}
-        </ul>
+                    <ChampionshipRosterEnrollAllDaysButton
+                        championshipId={championshipId}
+                        days={days}
+                        membershipNos={membershipNos}
+                        readOnly={readOnly}
+                    />
+                </div>
+            ) : null}
+            <table className="table table-sm">
+                <thead>
+                    <RosterEnrollmentHeader
+                        championshipId={championshipId}
+                        days={days}
+                        membershipNos={membershipNos}
+                        readOnly={readOnly}
+                    />
+                </thead>
+                <tbody>
+                    {registrations.map((registration) => (
+                        <RosterEnrollmentRow
+                            key={registration.id}
+                            championshipId={championshipId}
+                            registration={registration}
+                            days={days}
+                            enrolledDayOrders={new Set(enrollmentByMembership[registration.membershipNo] ?? [])}
+                            readOnly={readOnly}
+                            onEditRegistration={onEditRegistration ?? (() => undefined)}
+                        />
+                    ))}
+                </tbody>
+            </table>
+        </div>
     )
 }

--- a/src/app/championships/[cId]/ChampionshipRosterSection.tsx
+++ b/src/app/championships/[cId]/ChampionshipRosterSection.tsx
@@ -1,30 +1,50 @@
 "use client"
 
+import FormModal, { type FormModalHandle } from "@/components/FormModal"
 import ParticipantCSVImport from "@/components/participants/ParticipantCSVImport"
 import type { CSVImportState } from "@/lib/participantCsvImport"
 import { useRouter } from "next/navigation"
-import { useCallback } from "react"
+import { useCallback, useRef, useState } from "react"
 import { importChampionshipRegistrationsCSV } from "./championshipCsvImportActions"
-import ChampionshipRosterList, { type ChampionshipRegistrationRow } from "./ChampionshipRosterList"
+import ChampionshipRosterList, {
+    type ChampionshipRegistrationRow,
+    type ChampionshipRosterDayColumn,
+} from "./ChampionshipRosterList"
+import EditChampionshipCompetitorForm from "./EditChampionshipCompetitorForm"
 import RegisterChampionshipCompetitorForm from "./RegisterChampionshipCompetitorForm"
 import { ErrorContextProvider } from "@/components/errors/ErrorContext"
 
 export default function ChampionshipRosterSection({
     championshipId,
     registrations,
+    days,
+    enrollmentByMembership,
     readOnly = false,
 }: {
     championshipId: string
     registrations: ChampionshipRegistrationRow[]
+    days: ChampionshipRosterDayColumn[]
+    enrollmentByMembership: Record<string, number[]>
     readOnly?: boolean
 }) {
     const router = useRouter()
+    const editModalRef = useRef<FormModalHandle>(null)
+    const [editingRegistration, setEditingRegistration] = useState<ChampionshipRegistrationRow | null>(null)
 
     const handleImportComplete = useCallback((result: CSVImportState) => {
         if (result.success) {
             router.refresh()
         }
     }, [router])
+
+    const handleEditRegistration = useCallback((registration: ChampionshipRegistrationRow) => {
+        setEditingRegistration(registration)
+        editModalRef.current?.open()
+    }, [])
+
+    const closeEditModal = useCallback(() => {
+        editModalRef.current?.close()
+    }, [])
 
     return (
         <ErrorContextProvider>
@@ -49,9 +69,23 @@ export default function ChampionshipRosterSection({
                     <ChampionshipRosterList
                         championshipId={championshipId}
                         registrations={registrations}
+                        days={days}
+                        enrollmentByMembership={enrollmentByMembership}
                         readOnly={readOnly}
+                        onEditRegistration={readOnly ? undefined : handleEditRegistration}
                     />
                 </div>
+                {!readOnly ? (
+                    <FormModal ref={editModalRef}>
+                        {editingRegistration ? (
+                            <EditChampionshipCompetitorForm
+                                championshipId={championshipId}
+                                registration={editingRegistration}
+                                onClose={closeEditModal}
+                            />
+                        ) : null}
+                    </FormModal>
+                ) : null}
             </section>
         </ErrorContextProvider>
     )

--- a/src/app/championships/[cId]/ChampionshipRoundsList.tsx
+++ b/src/app/championships/[cId]/ChampionshipRoundsList.tsx
@@ -5,6 +5,7 @@ import { TrashIcon } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { removeChampionshipDay } from "../championshipActions"
+import { championshipDayCardClass, championshipDetailContentClass } from "./championshipDetailLayout"
 
 export type ChampionshipRoundRow = {
     id: string
@@ -83,13 +84,13 @@ export default function ChampionshipRoundsList({
     readOnly?: boolean
 }) {
     if (rounds.length === 0) {
-        return <p className="text-base-content/70">No tournament days linked yet. Add the first day to begin.</p>
+        return <p className={`text-base-content/70 ${championshipDetailContentClass}`}>No tournament days linked yet. Add the first day to begin.</p>
     }
 
     return (
-        <ul className="flex flex-col gap-3 w-full max-w-2xl">
+        <ul className={`flex flex-wrap gap-3 ${championshipDetailContentClass}`}>
             {rounds.map((round) => (
-                <li key={round.id} className="card bg-base-200 shadow-sm">
+                <li key={round.id} className={`card bg-base-200 shadow-sm ${championshipDayCardClass}`}>
                     <div className="card-body gap-2 py-4">
                         <div className="flex flex-wrap items-start justify-between gap-2">
                             <div className="flex flex-col gap-1">

--- a/src/app/championships/[cId]/EditChampionshipCompetitorForm.tsx
+++ b/src/app/championships/[cId]/EditChampionshipCompetitorForm.tsx
@@ -2,20 +2,30 @@
 
 import ParticipantProfileFields from "@/components/participants/ParticipantProfileFields"
 import useErrorContext from "@/components/errors/ErrorContext"
-import { UserPlusIcon } from "@heroicons/react/24/solid"
+import { PencilIcon } from "@heroicons/react/24/solid"
 import Form from "next/form"
 import { useRouter } from "next/navigation"
 import { useActionState, useEffect, useRef } from "react"
-import { submitRegisterChampionshipCompetitorForm } from "./registerChampionshipCompetitorAction"
-import { initialRegisterChampionshipCompetitorFormState } from "./registerChampionshipCompetitorFormState"
+import { participantProfileFromParticipant } from "@/lib/participantProfileFields"
+import type { ChampionshipRegistrationRow } from "./ChampionshipRosterList"
+import { submitEditChampionshipCompetitorForm } from "./editChampionshipCompetitorAction"
+import { initialEditChampionshipCompetitorFormState } from "./editChampionshipCompetitorFormState"
 import { championshipDetailContentClass } from "./championshipDetailLayout"
 
-export default function RegisterChampionshipCompetitorForm({ championshipId }: { championshipId: string }) {
+export default function EditChampionshipCompetitorForm({
+    championshipId,
+    registration,
+    onClose,
+}: {
+    championshipId: string
+    registration: ChampionshipRegistrationRow
+    onClose: () => void
+}) {
     const router = useRouter()
     const setError = useErrorContext()
     const [formState, formAction, isPending] = useActionState(
-        submitRegisterChampionshipCompetitorForm,
-        initialRegisterChampionshipCompetitorFormState
+        submitEditChampionshipCompetitorForm,
+        initialEditChampionshipCompetitorFormState
     )
     const handledSuccessRef = useRef(false)
     const errors = formState.errors ?? {}
@@ -25,8 +35,9 @@ export default function RegisterChampionshipCompetitorForm({ championshipId }: {
             return
         }
         handledSuccessRef.current = true
+        onClose()
         router.refresh()
-    }, [formState.success, router])
+    }, [formState.success, onClose, router])
 
     useEffect(() => {
         const errorMessages = Object.values(errors)
@@ -35,6 +46,8 @@ export default function RegisterChampionshipCompetitorForm({ championshipId }: {
         }
         setError(errorMessages.join(", "))
     }, [errors, setError])
+
+    const formData = formState.data ?? participantProfileFromParticipant(registration)
 
     return (
         <div className={`card bg-base-300 card-sm shadow-sm ${championshipDetailContentClass}`}>
@@ -46,12 +59,17 @@ export default function RegisterChampionshipCompetitorForm({ championshipId }: {
                     setError(undefined)
                 }}
             >
+                <h3 className="font-medium">Edit competitor #{registration.competitorNumber}</h3>
                 <input type="hidden" name="championshipId" value={championshipId} />
-                <ParticipantProfileFields errors={errors} data={formState.data} />
-                <div className="justify-end card-actions">
-                    <button type="submit" className="btn btn-success" disabled={isPending}>
-                        <UserPlusIcon width={20} />
-                        Register competitor
+                <input type="hidden" name="registrationId" value={registration.id} />
+                <ParticipantProfileFields errors={errors} data={formData} />
+                <div className="justify-end card-actions gap-2">
+                    <button type="button" className="btn btn-ghost" onClick={onClose} disabled={isPending}>
+                        Cancel
+                    </button>
+                    <button type="submit" className="btn btn-primary" disabled={isPending}>
+                        <PencilIcon width={20} />
+                        Save changes
                     </button>
                 </div>
             </Form>

--- a/src/app/championships/[cId]/championshipDetailLayout.ts
+++ b/src/app/championships/[cId]/championshipDetailLayout.ts
@@ -1,0 +1,3 @@
+export const championshipDetailContentClass = "w-full max-w-5xl"
+
+export const championshipDayCardClass = "flex-1 min-w-72"

--- a/src/app/championships/[cId]/editChampionshipCompetitorAction.ts
+++ b/src/app/championships/[cId]/editChampionshipCompetitorAction.ts
@@ -5,26 +5,28 @@ import { participantProfileFromFormData } from "@/lib/participantProfileFields"
 import { participantProfileSchema } from "@/lib/participantProfileSchema"
 import { z } from "zod"
 import { zu } from "zod_utilz"
-import { registerChampionshipParticipant } from "../championshipActions"
-import type { RegisterChampionshipCompetitorFormState } from "./registerChampionshipCompetitorFormState"
+import { updateChampionshipRegistration } from "../championshipActions"
+import type { EditChampionshipCompetitorFormState } from "./editChampionshipCompetitorFormState"
 
-const registerChampionshipCompetitorFormSchema = participantProfileSchema.extend({
+const editChampionshipCompetitorFormSchema = participantProfileSchema.extend({
     championshipId: z.string().min(1),
+    registrationId: z.string().min(1),
 })
 
 function formDataToInput(formData: FormData) {
     return {
         championshipId: formData.get("championshipId"),
+        registrationId: formData.get("registrationId"),
         ...participantProfileFromFormData(formData),
     }
 }
 
-export async function submitRegisterChampionshipCompetitorForm(
-    _initialState: RegisterChampionshipCompetitorFormState,
+export async function submitEditChampionshipCompetitorForm(
+    _initialState: EditChampionshipCompetitorFormState,
     formData: FormData
-): Promise<RegisterChampionshipCompetitorFormState> {
+): Promise<EditChampionshipCompetitorFormState> {
     const formInput = formDataToInput(formData)
-    const parsed = zu.partialSafeParse(registerChampionshipCompetitorFormSchema, formInput)
+    const parsed = zu.partialSafeParse(editChampionshipCompetitorFormSchema, formInput)
 
     if (!parsed.success || parsed.successType !== "full") {
         return {
@@ -34,13 +36,13 @@ export async function submitRegisterChampionshipCompetitorForm(
         }
     }
 
-    const input = registerChampionshipCompetitorFormSchema.parse(formInput)
+    const input = editChampionshipCompetitorFormSchema.parse(formInput)
 
     try {
-        await registerChampionshipParticipant(input)
+        await updateChampionshipRegistration(input.championshipId, input.registrationId, input)
         return { errors: {}, success: true }
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Unable to register competitor"
+        const message = error instanceof Error ? error.message : "Unable to update competitor"
         return {
             data: input,
             errors: { _form: message },

--- a/src/app/championships/[cId]/editChampionshipCompetitorFormState.ts
+++ b/src/app/championships/[cId]/editChampionshipCompetitorFormState.ts
@@ -1,0 +1,11 @@
+import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
+
+export type EditChampionshipCompetitorFormState = {
+    data?: Partial<ParticipantProfileInput>
+    errors: Record<string, string>
+    success?: boolean
+}
+
+export const initialEditChampionshipCompetitorFormState: EditChampionshipCompetitorFormState = {
+    errors: {},
+}

--- a/src/app/championships/[cId]/page.tsx
+++ b/src/app/championships/[cId]/page.tsx
@@ -7,7 +7,7 @@ import { auth } from "../../auth"
 import { notFound } from "next/navigation"
 import {
     getChampionshipForOrganizer,
-    listChampionshipEnrolledMembershipNos,
+    listChampionshipDayEnrollmentByTournament,
 } from "../championshipActions"
 import { competitorsRegisteredLabel } from "../competitorsRegisteredLabel"
 import ChampionshipDaysSection from "./ChampionshipDaysSection"
@@ -30,8 +30,21 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
         notFound()
     }
 
-    const enrolledMembershipNos = await listChampionshipEnrolledMembershipNos(cId, clubs)
-    const enrolledSet = new Set(enrolledMembershipNos ?? [])
+    const enrollmentByTournament = (await listChampionshipDayEnrollmentByTournament(cId, clubs)) ?? {}
+    const enrolledSet = new Set(Object.values(enrollmentByTournament).flat())
+
+    const rosterDays = championship.rounds.map((round) => ({
+        dayOrder: round.dayOrder,
+        label: round.tournament.name,
+    }))
+
+    const enrollmentByMembership: Record<string, number[]> = {}
+    for (const round of championship.rounds) {
+        for (const membershipNo of enrollmentByTournament[round.tournamentId] ?? []) {
+            enrollmentByMembership[membershipNo] ??= []
+            enrollmentByMembership[membershipNo].push(round.dayOrder)
+        }
+    }
 
     const rounds = championship.rounds.map((round) => ({
         id: round.id,
@@ -47,6 +60,9 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
         name: registration.name,
         membershipNo: registration.membershipNo,
         competitorNumber: registration.competitorNumber,
+        ageGroupId: registration.ageGroupId,
+        categoryId: registration.categoryId,
+        genderGroup: registration.genderGroup,
         ageGroupName: registration.ageGroup.name,
         categoryName: registration.category.name,
         club: registration.club,
@@ -81,6 +97,8 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
             <ChampionshipRosterSection
                 championshipId={championship.id}
                 registrations={registrations}
+                days={rosterDays}
+                enrollmentByMembership={enrollmentByMembership}
                 readOnly={championship.isArchive}
             />
         </div>

--- a/src/app/championships/__tests__/championshipActions.test.ts
+++ b/src/app/championships/__tests__/championshipActions.test.ts
@@ -16,6 +16,7 @@ import {
     unarchiveChampionship,
     unenrollChampionshipCompetitorFromDay,
     updateChampionship,
+    updateChampionshipRegistration,
 } from "../championshipActions"
 
 jest.mock("next/cache", () => ({
@@ -575,6 +576,75 @@ describe("unenrollChampionshipCompetitorFromDay", () => {
         await expect(unenrollChampionshipCompetitorFromDay("champ-1", 1, "M-001")).rejects.toThrow(
             "Competitor is not enrolled on this day"
         )
+    })
+})
+
+describe("updateChampionshipRegistration", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue(writableChampionshipShell as never)
+        prismaMock.championshipRegistration.findFirst.mockResolvedValue({
+            id: "reg-1",
+            membershipNo: "M-001",
+            competitorNumber: 1,
+        } as never)
+        prismaMock.$transaction.mockImplementation((callback) =>
+            typeof callback === "function" ? callback(prismaMock) : Promise.resolve(callback)
+        )
+        prismaMock.championshipRegistration.update.mockResolvedValue({ id: "reg-1" } as never)
+        prismaMock.participant.updateMany.mockResolvedValue({ count: 2 } as never)
+    })
+
+    it("updates registration and syncs enrolled day participants", async () => {
+        await expect(
+            updateChampionshipRegistration("champ-1", "reg-1", {
+                name: "Alex Updated",
+                membershipNo: "M-001",
+                ageGroupId: "age-2",
+                categoryId: "cat-2",
+                club: "Club B",
+                genderGroup: "F",
+            })
+        ).resolves.toBeUndefined()
+
+        expect(prismaMock.championshipRegistration.update).toHaveBeenCalledWith({
+            where: { id: "reg-1" },
+            data: {
+                name: "Alex Updated",
+                membershipNo: "M-001",
+                ageGroupId: "age-2",
+                categoryId: "cat-2",
+                club: "Club B",
+                genderGroup: "F",
+            },
+        })
+        expect(prismaMock.participant.updateMany).toHaveBeenCalledWith({
+            where: {
+                membershipNo: "M-001",
+                tournament: {
+                    championshipRound: { championshipId: "champ-1" },
+                },
+            },
+            data: expect.objectContaining({
+                name: "Alex Updated",
+                membershipNo: "M-001",
+                competitorNumber: 1,
+            }),
+        })
+    })
+
+    it("throws when registration is not found", async () => {
+        prismaMock.championshipRegistration.findFirst.mockResolvedValue(null)
+
+        await expect(
+            updateChampionshipRegistration("champ-1", "reg-missing", {
+                name: "Alex Updated",
+                membershipNo: "M-001",
+                ageGroupId: "age-2",
+                categoryId: "cat-2",
+                club: "Club B",
+                genderGroup: "F",
+            })
+        ).rejects.toThrow("Registration not found")
     })
 })
 

--- a/src/app/championships/__tests__/championshipActions.test.ts
+++ b/src/app/championships/__tests__/championshipActions.test.ts
@@ -2,16 +2,19 @@ import { prismaMock } from "@/test/prismaSingleton"
 import {
     addChampionshipDay,
     addRoundTournament,
+    archiveChampionship,
     createChampionship,
+    enrollChampionshipCompetitorsOnDay,
     getChampionshipForOrganizer,
+    listChampionshipDayEnrollmentByTournament,
     listChampionshipDayTournamentsForClubs,
     listChampionshipEnrolledMembershipNos,
     listMyChampionshipsForClubs,
     registerChampionshipParticipant,
-    archiveChampionship,
     removeChampionshipDay,
     removeChampionshipRegistration,
     unarchiveChampionship,
+    unenrollChampionshipCompetitorFromDay,
     updateChampionship,
 } from "../championshipActions"
 
@@ -375,7 +378,7 @@ const registrationInput = {
 
 describe("registerChampionshipParticipant", () => {
     beforeEach(() => {
-        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1" } as never)
+        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1", isArchive: false, rounds: [], registrations: [] } as never)
         prismaMock.championshipRegistration.aggregate.mockResolvedValue({
             _max: { competitorNumber: 0 },
         } as never)
@@ -422,15 +425,48 @@ describe("registerChampionshipParticipant", () => {
     })
 })
 
+describe("listChampionshipDayEnrollmentByTournament", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue({
+            id: "champ-1",
+            rounds: [
+                { tournamentId: "tour-1" },
+                { tournamentId: "tour-2" },
+            ],
+        } as never)
+    })
+
+    it("groups enrolled membership numbers by tournament", async () => {
+        prismaMock.participant.findMany.mockResolvedValue([
+            { membershipNo: "M-001", tournamentId: "tour-1" },
+            { membershipNo: "M-002", tournamentId: "tour-2" },
+        ] as never)
+
+        await expect(listChampionshipDayEnrollmentByTournament("champ-1", ["ClubA"])).resolves.toEqual({
+            "tour-1": ["M-001"],
+            "tour-2": ["M-002"],
+        })
+    })
+
+    it("returns null when championship is not in scope", async () => {
+        prismaMock.championship.findFirst.mockResolvedValue(null)
+
+        await expect(listChampionshipDayEnrollmentByTournament("champ-1", ["ClubA"])).resolves.toBeNull()
+    })
+})
+
 describe("listChampionshipEnrolledMembershipNos", () => {
     beforeEach(() => {
-        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1", rounds: [] } as never)
+        prismaMock.championship.findFirst.mockResolvedValue({
+            id: "champ-1",
+            rounds: [{ tournamentId: "tour-1" }],
+        } as never)
     })
 
     it("returns distinct membership numbers enrolled on championship days", async () => {
         prismaMock.participant.findMany.mockResolvedValue([
-            { membershipNo: "M-001" },
-            { membershipNo: "M-002" },
+            { membershipNo: "M-001", tournamentId: "tour-1" },
+            { membershipNo: "M-002", tournamentId: "tour-1" },
         ] as never)
 
         await expect(listChampionshipEnrolledMembershipNos("champ-1", ["ClubA"])).resolves.toEqual([
@@ -447,9 +483,104 @@ describe("listChampionshipEnrolledMembershipNos", () => {
     })
 })
 
+const writableChampionshipShell = {
+    id: "champ-1",
+    isArchive: false,
+    rounds: [{ dayOrder: 1, tournamentId: "tour-1" }],
+    registrations: [
+        {
+            membershipNo: "M-001",
+            name: "Alex Archer",
+            competitorNumber: 1,
+            ageGroupId: "age-1",
+            categoryId: "cat-1",
+            club: "Club A",
+            genderGroup: "M",
+        },
+        {
+            membershipNo: "M-002",
+            name: "Blake Bow",
+            competitorNumber: 2,
+            ageGroupId: "age-1",
+            categoryId: "cat-1",
+            club: "Club B",
+            genderGroup: "F",
+        },
+    ],
+}
+
+describe("enrollChampionshipCompetitorsOnDay", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue(writableChampionshipShell as never)
+        prismaMock.$transaction.mockImplementation((callback) =>
+            typeof callback === "function" ? callback(prismaMock) : Promise.resolve(callback)
+        )
+        prismaMock.participant.upsert.mockResolvedValue({ id: "part-1" } as never)
+    })
+
+    it("upserts participants copied from registrations", async () => {
+        await expect(
+            enrollChampionshipCompetitorsOnDay("champ-1", 1, ["M-001", "M-002"])
+        ).resolves.toEqual({ enrolledCount: 2 })
+
+        expect(prismaMock.participant.upsert).toHaveBeenNthCalledWith(1, {
+            where: {
+                tournamentId_membershipNo: {
+                    tournamentId: "tour-1",
+                    membershipNo: "M-001",
+                },
+            },
+            create: expect.objectContaining({
+                tournamentId: "tour-1",
+                membershipNo: "M-001",
+                competitorNumber: 1,
+                checkedIn: false,
+            }),
+            update: expect.objectContaining({
+                name: "Alex Archer",
+                competitorNumber: 1,
+            }),
+        })
+        expect(prismaMock.participant.upsert).toHaveBeenCalledTimes(2)
+    })
+
+    it("throws when membership number is not registered", async () => {
+        await expect(enrollChampionshipCompetitorsOnDay("champ-1", 1, ["M-999"])).rejects.toThrow(
+            "Not registered in championship: M-999"
+        )
+        expect(prismaMock.$transaction).not.toHaveBeenCalled()
+    })
+
+    it("returns zero when no membership numbers are provided", async () => {
+        await expect(enrollChampionshipCompetitorsOnDay("champ-1", 1, [])).resolves.toEqual({ enrolledCount: 0 })
+        expect(prismaMock.$transaction).not.toHaveBeenCalled()
+    })
+})
+
+describe("unenrollChampionshipCompetitorFromDay", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue(writableChampionshipShell as never)
+        prismaMock.participant.findFirst.mockResolvedValue({ id: "part-1" } as never)
+        prismaMock.participant.delete.mockResolvedValue({ id: "part-1", tournamentId: "tour-1" } as never)
+    })
+
+    it("deletes the day participant row", async () => {
+        await expect(unenrollChampionshipCompetitorFromDay("champ-1", 1, "M-001")).resolves.toBeUndefined()
+        expect(prismaMock.participant.delete).toHaveBeenCalledWith({ where: { id: "part-1" } })
+    })
+
+    it("throws when competitor is not enrolled on the day", async () => {
+        prismaMock.participant.findFirst.mockResolvedValue(null)
+
+        await expect(unenrollChampionshipCompetitorFromDay("champ-1", 1, "M-001")).rejects.toThrow(
+            "Competitor is not enrolled on this day"
+        )
+    })
+})
+
 describe("removeChampionshipRegistration", () => {
     beforeEach(() => {
-        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1" } as never)
+        prismaMock.championship.findFirst.mockResolvedValue({ id: "champ-1", isArchive: false, rounds: [], registrations: [] } as never)
     })
 
     it("removes registration when competitor is not enrolled on any day", async () => {

--- a/src/app/championships/championshipActions.ts
+++ b/src/app/championships/championshipActions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache"
 import { Prisma } from "@/generated/prisma/client"
 import { championshipDayTournamentName, nextChampionshipDayOrder } from "@/lib/championshipDayNaming"
 import { assertChampionshipOrganizerClubs, resolveChampionshipOrganizerClubs } from "@/lib/championshipOrganizerSession"
+import { participantDataFromRegistration, participantUpdateFromRegistration } from "@/lib/championshipEnrollment"
 import { prismaOrThrow } from "@/lib/prisma"
 
 export interface ChampionshipCreateInput {
@@ -245,12 +246,12 @@ async function assertChampionshipAccessForId(championshipId: string): Promise<vo
 }
 
 export async function assertChampionshipWritable(championshipId: string): Promise<void> {
-    await assertChampionshipAccessForId(championshipId)
-    const championship = await prismaOrThrow("get championship archive state").championship.findFirst({
-        where: { id: championshipId },
-        select: { isArchive: true },
-    })
-    if (championship?.isArchive) {
+    const clubs = await assertChampionshipOrganizerClubs()
+    const championship = await getChampionshipForOrganizer(championshipId, clubs)
+    if (!championship) {
+        throw new Error("Unauthorized")
+    }
+    if (championship.isArchive) {
         throw new Error("Championship is archived")
     }
 }
@@ -478,31 +479,209 @@ export async function listChampionshipEnrolledMembershipNos(
     championshipId: string,
     organizerClubs: string[]
 ): Promise<string[] | null> {
+    const byTournament = await listChampionshipDayEnrollmentByTournament(championshipId, organizerClubs)
+    if (!byTournament) {
+        return null
+    }
+
+    return [...new Set(Object.values(byTournament).flat())]
+}
+
+export async function listChampionshipDayEnrollmentByTournament(
+    championshipId: string,
+    organizerClubs: string[]
+): Promise<Record<string, string[]> | null> {
     const championship = await getChampionshipForOrganizer(championshipId, organizerClubs)
     if (!championship) {
         return null
     }
 
-    const participants = await prismaOrThrow("list championship enrolled membership numbers")
-        .participant.findMany({
-            where: {
-                tournament: {
-                    championshipRound: { championshipId },
-                },
+    const participants = await prismaOrThrow("list championship day enrollments").participant.findMany({
+        where: {
+            tournament: {
+                championshipRound: { championshipId },
             },
-            select: { membershipNo: true },
-            distinct: ["membershipNo"],
-        })
-        .catch((error) => {
-            logAndReturnNull("Failed to list enrolled competitors", error)
-            return null
-        })
+        },
+        select: { membershipNo: true, tournamentId: true },
+    }).catch((error) => {
+        logAndReturnNull("Failed to list day enrollments", error)
+        return null
+    })
 
     if (!participants) {
         return null
     }
 
-    return participants.map((row) => row.membershipNo)
+    const byTournament = Object.fromEntries(
+        championship.rounds.map((round) => [round.tournamentId, [] as string[]])
+    )
+
+    for (const participant of participants) {
+        const membershipNos = byTournament[participant.tournamentId]
+        if (membershipNos) {
+            membershipNos.push(participant.membershipNo)
+        }
+    }
+
+    return byTournament
+}
+
+async function getWritableChampionshipShell(championshipId: string): Promise<ChampionshipShellRow> {
+    const clubs = await assertChampionshipOrganizerClubs()
+    const championship = await getChampionshipForOrganizer(championshipId, clubs)
+    if (!championship) {
+        throw new Error("Unauthorized")
+    }
+    if (championship.isArchive) {
+        throw new Error("Championship is archived")
+    }
+    return championship
+}
+
+function getChampionshipRoundByDayOrder(championship: ChampionshipShellRow, dayOrder: number) {
+    const round = championship.rounds.find((item) => item.dayOrder === dayOrder)
+    if (!round) {
+        throw new Error("Championship day not found")
+    }
+    return round
+}
+
+export async function enrollChampionshipCompetitorsOnDay(
+    championshipId: string,
+    dayOrder: number,
+    membershipNos: string[]
+) {
+    const uniqueMembershipNos = [...new Set(membershipNos.map((membershipNo) => membershipNo.trim()).filter(Boolean))]
+    if (uniqueMembershipNos.length === 0) {
+        return { enrolledCount: 0 }
+    }
+
+    const championship = await getWritableChampionshipShell(championshipId)
+    const round = getChampionshipRoundByDayOrder(championship, dayOrder)
+    const registrationByMembership = new Map(
+        championship.registrations.map((registration) => [registration.membershipNo, registration])
+    )
+
+    const missingMembershipNos = uniqueMembershipNos.filter((membershipNo) => !registrationByMembership.has(membershipNo))
+    if (missingMembershipNos.length > 0) {
+        throw new Error(`Not registered in championship: ${missingMembershipNos.join(", ")}`)
+    }
+
+    await prismaOrThrow("enroll championship competitors on day").$transaction(async (tx) => {
+        for (const membershipNo of uniqueMembershipNos) {
+            const registration = registrationByMembership.get(membershipNo)!
+            await tx.participant.upsert({
+                where: {
+                    tournamentId_membershipNo: {
+                        tournamentId: round.tournamentId,
+                        membershipNo,
+                    },
+                },
+                create: participantDataFromRegistration(registration, round.tournamentId),
+                update: participantUpdateFromRegistration(registration),
+            })
+        }
+    })
+
+    revalidatePath(`/championships/${championshipId}`)
+    revalidatePath(`/tournaments/${round.tournamentId}`)
+    return { enrolledCount: uniqueMembershipNos.length }
+}
+
+export async function unenrollChampionshipCompetitorFromDay(
+    championshipId: string,
+    dayOrder: number,
+    membershipNo: string
+) {
+    const trimmedMembershipNo = membershipNo.trim()
+    if (!trimmedMembershipNo) {
+        throw new Error("Membership number is required")
+    }
+
+    const championship = await getWritableChampionshipShell(championshipId)
+    const round = getChampionshipRoundByDayOrder(championship, dayOrder)
+
+    const participant = await prismaOrThrow("find day participant for unenroll").participant.findFirst({
+        where: {
+            tournamentId: round.tournamentId,
+            membershipNo: trimmedMembershipNo,
+        },
+        select: { id: true },
+    })
+
+    if (!participant) {
+        throw new Error("Competitor is not enrolled on this day")
+    }
+
+    await prismaOrThrow("unenroll championship competitor from day").participant.delete({
+        where: { id: participant.id },
+    })
+
+    revalidatePath(`/championships/${championshipId}`)
+    revalidatePath(`/tournaments/${round.tournamentId}`)
+}
+
+export async function updateChampionshipRegistration(
+    championshipId: string,
+    registrationId: string,
+    input: Omit<RegisterChampionshipParticipantInput, "championshipId">
+) {
+    await assertChampionshipWritable(championshipId)
+
+    const registration = await prismaOrThrow("find championship registration for update")
+        .championshipRegistration.findFirst({
+            where: { id: registrationId, championshipId },
+        })
+
+    if (!registration) {
+        throw new Error("Registration not found")
+    }
+
+    const championship = await getWritableChampionshipShell(championshipId)
+    const oldMembershipNo = registration.membershipNo
+    const trimmedProfile = {
+        name: input.name.trim(),
+        membershipNo: input.membershipNo.trim(),
+        ageGroupId: input.ageGroupId,
+        categoryId: input.categoryId,
+        club: input.club.trim(),
+        genderGroup: input.genderGroup,
+    }
+
+    try {
+        await prismaOrThrow("update championship registration").$transaction(async (tx) => {
+            await tx.championshipRegistration.update({
+                where: { id: registrationId },
+                data: trimmedProfile,
+            })
+
+            await tx.participant.updateMany({
+                where: {
+                    membershipNo: oldMembershipNo,
+                    tournament: {
+                        championshipRound: { championshipId },
+                    },
+                },
+                data: {
+                    ...participantUpdateFromRegistration({
+                        ...trimmedProfile,
+                        competitorNumber: registration.competitorNumber,
+                    }),
+                    membershipNo: trimmedProfile.membershipNo,
+                },
+            })
+        })
+    } catch (error) {
+        if (isUniqueError(error) && getUniqueConstraintFields(error).includes("membershipNo")) {
+            throw new Error("This membership number is already registered in this championship")
+        }
+        throw error
+    }
+
+    revalidatePath(`/championships/${championshipId}`)
+    for (const round of championship.rounds) {
+        revalidatePath(`/tournaments/${round.tournamentId}`)
+    }
 }
 
 export async function removeChampionshipRegistration(championshipId: string, registrationId: string) {

--- a/src/app/tournaments/[tId]/AddParticipantForm.tsx
+++ b/src/app/tournaments/[tId]/AddParticipantForm.tsx
@@ -1,54 +1,54 @@
-'use client'
-import AgeDivisionSelect from "./components/AgeDivisionSelect"
-import EquipmentCategorySelect from "./components/EquipmentCategorySelect"
+"use client"
 
 import ErrorAlert from "@/components/errors/ErrorAlert"
+import ParticipantProfileFields from "@/components/participants/ParticipantProfileFields"
+import { participantProfileFromParticipant } from "@/lib/participantProfileFields"
+import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
 import { Participant } from "@/generated/prisma/browser"
 import { CheckCircleIcon, PencilIcon, PlusCircleIcon, XMarkIcon } from "@heroicons/react/24/outline"
 import Form from "next/form"
 import { useActionState, useState } from "react"
-import GenderSelect from "./components/GenderSelect"
 import { AddParticipantState, addParticipant } from "./participantActions"
 
 const initialState: AddParticipantState = {
     data: {},
-    errors: {}
+    errors: {},
 }
 
-interface AddParticipantFormProps {
+export default function AddParticipantForm({
+    tId,
+    participant,
+    onCancel,
+}: {
     tId: string
     participant?: Participant | null
     onCancel?: () => void
-}
-
-export default function AddParticipantForm({ tId, participant, onCancel }: AddParticipantFormProps) {
+}) {
     const participantId = participant?.id
 
     const [formState, formAction, isPending] = useActionState(addParticipant, initialState, `/tournaments/${tId}`)
 
     const errorSummary =
         Object.keys(formState.errors).length > 0
-            ? Object.values(formState.errors).join(', ')
+            ? Object.values(formState.errors).join(", ")
             : undefined
 
     const [errorBannerDismissed, setErrorBannerDismissed] = useState(false)
     const visibleError = errorSummary && !errorBannerDismissed ? errorSummary : undefined
 
-    const defaultName = participant?.name || formState.data?.name || ''
-    const defaultMembershipNo = participant?.membershipNo || formState.data?.membershipNo || ''
-    const defaultClub = participant?.club || formState.data?.club || ''
-    const defaultAgeGroupId = participant?.ageGroupId || formState.data?.ageGroupId || ''
-    const defaultGenderGroup = participant?.genderGroup || formState.data?.genderGroup
-    const defaultCategoryId = participant?.categoryId || formState.data?.categoryId || ''
+    const profileData: Partial<ParticipantProfileInput> = {
+        ...participantProfileFromParticipant(participant ?? {}),
+        ...formState.data,
+    }
     const defaultCheckedIn = participant?.checkedIn ?? formState.data?.checkedIn ?? false
 
     return (
         <div className="my-2 flex flex-col gap-1">
-            {participantId && (
+            {participantId ? (
                 <div className="flex items-center justify-between mb-1 text-xs">
                     <span className="font-semibold">Editing: {participant?.name}</span>
                 </div>
-            )}
+            ) : null}
             <Form
                 action={formAction}
                 className="flex mx-auto gap-1 items-center items-stretch"
@@ -57,44 +57,56 @@ export default function AddParticipantForm({ tId, participant, onCancel }: AddPa
                 }}
             >
                 <input type="hidden" name="tId" value={tId} />
-                <input type="hidden" name="participantId" value={participantId || ''} />
-                <div className="flex-1 flex gap-1 flex-wrap items-stretch">
-                    <input type="text" name="name" className={`sm:w-2/5 input input-xs md:input-sm flex-grow ${formState.errors?.name ? 'input-error' : 'input-secondary'}`} placeholder="Archer's Name" defaultValue={defaultName} />
-                    <input type="text" name="membershipNo" className={`w-fit input input-xs md:input-sm flex-grow ${formState.errors?.membershipNo ? 'input-error' : 'input-secondary'}`} placeholder="Membership No." defaultValue={defaultMembershipNo} />
-                    <input type="text" name="club" className={`sm:w-2/5 input input-xs md:input-sm flex-grow ${formState.errors?.club ? 'input-error' : 'input-secondary'}`} placeholder="Archer's Club" defaultValue={defaultClub} required />
-                    <AgeDivisionSelect name="ageGroupId" className="min-w-fit select select-xs md:select-sm select-secondary w-2/5 md:w-1/3 flex-1" defaultValue={defaultAgeGroupId} />
-                    <GenderSelect name="genderGroup" className="min-w-fit select select-xs md:select-sm select-secondary w-2/5 md:w-1/3 flex-1" defaultValue={defaultGenderGroup} />
-                    <EquipmentCategorySelect name="categoryId" className="min-w-fit select select-xs md:select-sm select-secondary md:w-1/3 flex-1 " defaultValue={defaultCategoryId} />
-                </div>
+                <input type="hidden" name="participantId" value={participantId || ""} />
+                <ParticipantProfileFields errors={formState.errors ?? {}} data={profileData} layout="inline" />
                 <div className="flex-0 flex flex-col gap-1">
                     {participantId ? (
                         <>
-                            {onCancel && (
+                            {onCancel ? (
                                 <button type="button" onClick={onCancel} className="btn btn-sm btn-ghost">
                                     <XMarkIcon className="w-4 h-4" />
                                     <span className="hidden md:inline">Cancel</span>
                                 </button>
-                            )}
-
-                            <button type="submit" name="checkedIn" value={defaultCheckedIn ? 'true' : 'false'} className="flex-1 min-w-fit btn btn-xs md:btn-sm btn-primary" disabled={isPending}>
+                            ) : null}
+                            <button
+                                type="submit"
+                                name="checkedIn"
+                                value={defaultCheckedIn ? "true" : "false"}
+                                className="flex-1 min-w-fit btn btn-xs md:btn-sm btn-primary"
+                                disabled={isPending}
+                            >
                                 <PencilIcon className="w-4 h-4" />
                                 <span className="hidden md:block">Update</span>
                             </button>
-
                         </>
                     ) : (
                         <>
-                            <button type="submit" name="checkedIn" value="false" className="flex-1 min-w-fit btn btn-xs md:btn-sm btn-secondary" disabled={isPending}><PlusCircleIcon className="w-4 h-4" /><span className="hidden md:block">Preregister</span></button>
-                            <button type="submit" name="checkedIn" value="true" className="flex-1 min-w-fit btn btn-xs md:btn-sm btn-success" disabled={isPending}><CheckCircleIcon className="w-4 h-4" /><span className="hidden md:block">Check&nbsp;In</span></button>
+                            <button
+                                type="submit"
+                                name="checkedIn"
+                                value="false"
+                                className="flex-1 min-w-fit btn btn-xs md:btn-sm btn-secondary"
+                                disabled={isPending}
+                            >
+                                <PlusCircleIcon className="w-4 h-4" />
+                                <span className="hidden md:block">Preregister</span>
+                            </button>
+                            <button
+                                type="submit"
+                                name="checkedIn"
+                                value="true"
+                                className="flex-1 min-w-fit btn btn-xs md:btn-sm btn-success"
+                                disabled={isPending}
+                            >
+                                <CheckCircleIcon className="w-4 h-4" />
+                                <span className="hidden md:block">Check&nbsp;In</span>
+                            </button>
                         </>
                     )}
                 </div>
                 <input type="hidden" name="target" value={`/tournaments/[tId]/`} />
             </Form>
-            <ErrorAlert
-                error={visibleError}
-                resetAction={() => setErrorBannerDismissed(true)}
-            />
+            <ErrorAlert error={visibleError} resetAction={() => setErrorBannerDismissed(true)} />
         </div>
     )
 }

--- a/src/app/tournaments/[tId]/ChampionshipDayParticipantsNotice.tsx
+++ b/src/app/tournaments/[tId]/ChampionshipDayParticipantsNotice.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import type { ChampionshipDayLink } from "@/app/tournaments/tournamentActions"
+import Link from "next/link"
+
+export default function ChampionshipDayParticipantsNotice({
+    championshipDay,
+}: {
+    championshipDay: ChampionshipDayLink
+}) {
+    return (
+        <div role="note" className="alert alert-info alert-soft my-2">
+            <span className="text-sm">
+                Add and edit competitors on the{" "}
+                <Link href={`/championships/${championshipDay.championshipId}`} className="link font-medium">
+                    {championshipDay.championshipName}
+                </Link>{" "}
+                roster, then enroll them on this day.
+            </span>
+        </div>
+    )
+}

--- a/src/app/tournaments/[tId]/ParticipantsList.tsx
+++ b/src/app/tournaments/[tId]/ParticipantsList.tsx
@@ -11,11 +11,17 @@ import ParticipantsListRow from "./ParticipantsListRow"
 
 interface ParticipantsListProps {
     participants: Participant[]
+    allowImportAndEdit?: boolean
     onEditParticipant?: (participant: Participant | null) => void
     editingParticipantId?: string | null
 }
 
-export default function ParticipantsList({ participants, onEditParticipant, editingParticipantId }: ParticipantsListProps) {
+export default function ParticipantsList({
+    participants,
+    allowImportAndEdit = true,
+    onEditParticipant,
+    editingParticipantId,
+}: ParticipantsListProps) {
     const [importFeedback, setImportFeedback] = useState<string | null>(null)
     const [displayP, setDisplayP] = useState(participants)
     const [filteredParticipants, setFilteredParticipants] = useState(participants)
@@ -104,7 +110,7 @@ export default function ParticipantsList({ participants, onEditParticipant, edit
                     />
                 </div>
                 <div className="hidden md:block md:w-32">
-                    <CSVImport onImportComplete={handleImportComplete} />
+                    {allowImportAndEdit ? <CSVImport onImportComplete={handleImportComplete} /> : null}
                 </div>
             </div>
 

--- a/src/app/tournaments/[tId]/ParticipantsSection.tsx
+++ b/src/app/tournaments/[tId]/ParticipantsSection.tsx
@@ -1,17 +1,23 @@
 "use client"
 
 import { type ParticipantModel as Participant } from "@/generated/prisma/models/Participant"
+import type { ChampionshipDayLink } from "@/app/tournaments/tournamentActions"
 import { useState } from "react"
 import AddParticipantForm from "./AddParticipantForm"
+import ChampionshipDayParticipantsNotice from "./ChampionshipDayParticipantsNotice"
 import ParticipantsList from "./ParticipantsList"
 
-interface ParticipantsSectionProps {
+export default function ParticipantsSection({
+    tId,
+    participants,
+    championshipDay = null,
+}: {
     tId: string
     participants: Participant[]
-}
-
-export default function ParticipantsSection({ tId, participants }: ParticipantsSectionProps) {
+    championshipDay?: ChampionshipDayLink | null
+}) {
     const [editingParticipant, setEditingParticipant] = useState<Participant | null>(null)
+    const isChampionshipDay = championshipDay !== null
 
     const handleEditParticipant = (participant: Participant | null) => {
         setEditingParticipant(participant)
@@ -23,18 +29,22 @@ export default function ParticipantsSection({ tId, participants }: ParticipantsS
 
     return (
         <>
-            <AddParticipantForm
-                key={editingParticipant?.id || 'new'}
-                tId={tId}
-                participant={editingParticipant}
-                onCancel={editingParticipant ? handleCancelEdit : undefined}
-            />
+            {isChampionshipDay ? (
+                <ChampionshipDayParticipantsNotice championshipDay={championshipDay} />
+            ) : (
+                <AddParticipantForm
+                    key={editingParticipant?.id || "new"}
+                    tId={tId}
+                    participant={editingParticipant}
+                    onCancel={editingParticipant ? handleCancelEdit : undefined}
+                />
+            )}
             <ParticipantsList
                 participants={participants}
-                onEditParticipant={handleEditParticipant}
+                allowImportAndEdit={!isChampionshipDay}
+                onEditParticipant={isChampionshipDay ? undefined : handleEditParticipant}
                 editingParticipantId={editingParticipant?.id || null}
             />
         </>
     )
 }
-

--- a/src/app/tournaments/[tId]/page.tsx
+++ b/src/app/tournaments/[tId]/page.tsx
@@ -1,5 +1,5 @@
 import { ErrorContextProvider } from "@/components/errors/ErrorContext"
-import { getTournamentById } from "../tournamentActions"
+import { getTournamentById, getChampionshipDayLinkForTournament } from "../tournamentActions"
 import ParticipantsSection from "./ParticipantsSection"
 import { TournamentEditContextProvider } from "./TournamentContext"
 import TournamentEditForm from "./TournamentEditForm"
@@ -21,6 +21,7 @@ export default async function TournamentDetailsPage({ params }: { params: Promis
     }
 
     const participants = await listParticipants(tournament.id)
+    const championshipDay = await getChampionshipDayLinkForTournament(tournament.id)
 
     return (
         <div className="w-full min-h-max">
@@ -29,7 +30,11 @@ export default async function TournamentDetailsPage({ params }: { params: Promis
                     <TournamentEditForm />
                     <TournamentNavigation tournamentId={tournament.id} />
                     <div className="border border-secondary border-solid w-full min-h-max">
-                        <ParticipantsSection tId={tournament.id} participants={participants} />
+                        <ParticipantsSection
+                            tId={tournament.id}
+                            participants={participants}
+                            championshipDay={championshipDay}
+                        />
                     </div>
                 </ErrorContextProvider>
             </TournamentEditContextProvider>

--- a/src/app/tournaments/[tId]/participantActions.ts
+++ b/src/app/tournaments/[tId]/participantActions.ts
@@ -1,5 +1,6 @@
 "use server"
 
+import { participantProfileFromFormData } from "@/lib/participantProfileFields"
 import { participantProfileSchema } from "@/lib/participantProfileSchema"
 import { prismaOrThrow } from "@/lib/prisma"
 import { revalidatePath } from "next/cache"
@@ -35,14 +36,9 @@ export async function addParticipant(initialState: AddParticipantState, fd: Form
     const checkedIn = checkedInValue === 'true'
 
     const fdConstructed = {
-        tournamentId: fd.get('tId'),
-        name: fd.get('name'),
-        membershipNo: fd.get('membershipNo'),
-        genderGroup: fd.get('genderGroup'),
-        ageGroupId: fd.get('ageGroupId'),
-        categoryId: fd.get('categoryId'),
-        club: fd.get('club'),
-        checkedIn
+        tournamentId: fd.get("tId"),
+        ...participantProfileFromFormData(fd),
+        checkedIn,
     }
 
     const participant = zu.partialSafeParse(participantSubmitSchema, fdConstructed)

--- a/src/components/participants/ParticipantProfileFields.tsx
+++ b/src/components/participants/ParticipantProfileFields.tsx
@@ -4,81 +4,148 @@ import AgeDivisionSelect from "@/app/tournaments/[tId]/components/AgeDivisionSel
 import EquipmentCategorySelect from "@/app/tournaments/[tId]/components/EquipmentCategorySelect"
 import GenderSelect from "@/app/tournaments/[tId]/components/GenderSelect"
 import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
+import {
+    getParticipantProfileFieldDefinition,
+    participantProfileFieldGroups,
+    participantProfileFields,
+    type ParticipantProfileFieldDefinition,
+    type ParticipantProfileFieldKey,
+} from "@/lib/participantProfileFields"
 
 function fieldClass(hasError: boolean, baseClass: string): string {
     return hasError ? `${baseClass} input-error` : baseClass
 }
 
-export default function ParticipantProfileFields({
+function renderProfileControl({
+    field,
+    errors,
+    data,
+    inputClassName,
+    selectClassName,
+}: {
+    field: ParticipantProfileFieldDefinition
+    errors: Record<string, string>
+    data?: Partial<ParticipantProfileInput>
+    inputClassName: string
+    selectClassName: string
+}) {
+    const value = data?.[field.key]
+
+    if (field.kind === "text") {
+        return (
+            <input
+                type="text"
+                name={field.key}
+                className={fieldClass(!!errors[field.key], inputClassName)}
+                placeholder={field.placeholder}
+                defaultValue={typeof value === "string" ? value : ""}
+                required
+            />
+        )
+    }
+
+    if (field.kind === "ageGroup") {
+        return (
+            <AgeDivisionSelect
+                name={field.key}
+                className={fieldClass(!!errors[field.key], selectClassName)}
+                defaultValue={typeof value === "string" ? value : ""}
+            />
+        )
+    }
+
+    if (field.kind === "gender") {
+        return (
+            <GenderSelect
+                name={field.key}
+                className={fieldClass(!!errors[field.key], selectClassName)}
+                defaultValue={value === "F" || value === "M" ? value : undefined}
+            />
+        )
+    }
+
+    return (
+        <EquipmentCategorySelect
+            name={field.key}
+            className={fieldClass(!!errors[field.key], selectClassName)}
+            defaultValue={typeof value === "string" ? value : ""}
+        />
+    )
+}
+
+function StackedField({
+    fieldKey,
     errors,
     data,
 }: {
+    fieldKey: ParticipantProfileFieldKey
     errors: Record<string, string>
     data?: Partial<ParticipantProfileInput>
 }) {
+    const field = getParticipantProfileFieldDefinition(fieldKey)
+
+    return (
+        <label className="form-control flex-1 min-w-40">
+            <span className="label-text">{field.label}</span>
+            {renderProfileControl({
+                field,
+                errors,
+                data,
+                inputClassName: "input input-bordered w-full",
+                selectClassName: "select select-bordered w-full",
+            })}
+        </label>
+    )
+}
+
+function InlineField({
+    fieldKey,
+    errors,
+    data,
+}: {
+    fieldKey: ParticipantProfileFieldKey
+    errors: Record<string, string>
+    data?: Partial<ParticipantProfileInput>
+}) {
+    const field = getParticipantProfileFieldDefinition(fieldKey)
+
+    return renderProfileControl({
+        field,
+        errors,
+        data,
+        inputClassName: "sm:w-2/5 input input-xs md:input-sm flex-grow input-secondary",
+        selectClassName: "min-w-fit select select-xs md:select-sm select-secondary w-2/5 md:w-1/3 flex-1",
+    })
+}
+
+export default function ParticipantProfileFields({
+    errors,
+    data,
+    layout = "stacked",
+}: {
+    errors: Record<string, string>
+    data?: Partial<ParticipantProfileInput>
+    layout?: "stacked" | "inline"
+}) {
+    if (layout === "inline") {
+        return (
+            <div className="flex-1 flex gap-1 flex-wrap items-stretch">
+                {participantProfileFields.map((field) => (
+                    <InlineField key={field.key} fieldKey={field.key} errors={errors} data={data} />
+                ))}
+            </div>
+        )
+    }
+
     return (
         <div className="flex flex-col gap-3">
-            <div className="flex flex-wrap gap-3">
-                <label className="form-control flex-1 min-w-48">
-                    <span className="label-text">Archer&apos;s name</span>
-                    <input
-                        type="text"
-                        name="name"
-                        className={fieldClass(!!errors.name, "input input-bordered w-full")}
-                        placeholder="Archer's name"
-                        defaultValue={data?.name ?? ""}
-                        required
-                    />
-                </label>
-                <label className="form-control flex-1 min-w-40">
-                    <span className="label-text">Membership number</span>
-                    <input
-                        type="text"
-                        name="membershipNo"
-                        className={fieldClass(!!errors.membershipNo, "input input-bordered w-full")}
-                        placeholder="Membership no."
-                        defaultValue={data?.membershipNo ?? ""}
-                        required
-                    />
-                </label>
-                <label className="form-control flex-1 min-w-40">
-                    <span className="label-text">Club</span>
-                    <input
-                        type="text"
-                        name="club"
-                        className={fieldClass(!!errors.club, "input input-bordered w-full")}
-                        placeholder="Club"
-                        defaultValue={data?.club ?? ""}
-                        required
-                    />
-                </label>
-            </div>
-            <div className="flex flex-wrap gap-3">
-                <label className="form-control flex-1 min-w-40">
-                    <span className="label-text">Age division</span>
-                    <AgeDivisionSelect
-                        name="ageGroupId"
-                        className={fieldClass(!!errors.ageGroupId, "select select-bordered w-full")}
-                        defaultValue={data?.ageGroupId ?? ""}
-                    />
-                </label>
-                <label className="form-control flex-1 min-w-32">
-                    <span className="label-text">Gender</span>
-                    <GenderSelect
-                        name="genderGroup"
-                        className={fieldClass(!!errors.genderGroup, "select select-bordered w-full")}
-                        defaultValue={data?.genderGroup}
-                    />
-                </label>
-                <label className="form-control flex-1 min-w-40">
-                    <span className="label-text">Equipment category</span>
-                    <EquipmentCategorySelect
-                        name="categoryId"
-                        className={fieldClass(!!errors.categoryId, "select select-bordered w-full")}
-                        defaultValue={data?.categoryId ?? ""}
-                    />
-                </label>
-            </div>
+            {participantProfileFieldGroups.map((group) => (
+                <div key={group.join("-")} className="flex flex-wrap gap-3">
+                    {group.map((fieldKey) => (
+                        <StackedField key={fieldKey} fieldKey={fieldKey} errors={errors} data={data} />
+                    ))}
+                </div>
+            ))}
         </div>
     )
 }

--- a/src/lib/__tests__/championshipEnrollment.test.ts
+++ b/src/lib/__tests__/championshipEnrollment.test.ts
@@ -1,0 +1,42 @@
+import { GenderGroup } from "@/generated/prisma/enums"
+import {
+    participantDataFromRegistration,
+    participantUpdateFromRegistration,
+} from "@/lib/championshipEnrollment"
+
+describe("championshipEnrollment", () => {
+    const registration = {
+        name: "Alex Archer",
+        membershipNo: "M-001",
+        competitorNumber: 7,
+        ageGroupId: "age-1",
+        categoryId: "cat-1",
+        club: "Club A",
+        genderGroup: GenderGroup.M,
+    }
+
+    it("maps registration to participant create data", () => {
+        expect(participantDataFromRegistration(registration, "tour-1")).toEqual({
+            tournamentId: "tour-1",
+            name: "Alex Archer",
+            membershipNo: "M-001",
+            competitorNumber: 7,
+            ageGroupId: "age-1",
+            categoryId: "cat-1",
+            club: "Club A",
+            genderGroup: GenderGroup.M,
+            checkedIn: false,
+        })
+    })
+
+    it("maps registration to participant update data without checkedIn", () => {
+        expect(participantUpdateFromRegistration(registration)).toEqual({
+            name: "Alex Archer",
+            competitorNumber: 7,
+            ageGroupId: "age-1",
+            categoryId: "cat-1",
+            club: "Club A",
+            genderGroup: GenderGroup.M,
+        })
+    })
+})

--- a/src/lib/__tests__/participantProfileFields.test.ts
+++ b/src/lib/__tests__/participantProfileFields.test.ts
@@ -1,0 +1,39 @@
+import {
+    participantProfileFieldKeys,
+    participantProfileFields,
+    participantProfileFromFormData,
+} from "@/lib/participantProfileFields"
+import { participantProfileSchema } from "@/lib/participantProfileSchema"
+
+describe("participantProfileFields", () => {
+    it("lists the same keys as participantProfileSchema", () => {
+        expect(participantProfileFieldKeys.sort()).toEqual(
+            Object.keys(participantProfileSchema.shape).sort()
+        )
+    })
+
+    it("defines metadata for every schema key", () => {
+        expect(participantProfileFields.map((field) => field.key).sort()).toEqual(
+            participantProfileFieldKeys.sort()
+        )
+    })
+
+    it("reads profile values from form data", () => {
+        const formData = new FormData()
+        formData.set("name", "Alex Archer")
+        formData.set("membershipNo", "M-001")
+        formData.set("club", "Club A")
+        formData.set("ageGroupId", "A")
+        formData.set("genderGroup", "M")
+        formData.set("categoryId", "BBC")
+
+        expect(participantProfileFromFormData(formData)).toEqual({
+            name: "Alex Archer",
+            membershipNo: "M-001",
+            club: "Club A",
+            ageGroupId: "A",
+            genderGroup: "M",
+            categoryId: "BBC",
+        })
+    })
+})

--- a/src/lib/championshipEnrollment.ts
+++ b/src/lib/championshipEnrollment.ts
@@ -1,0 +1,34 @@
+import type { ChampionshipRegistration, GenderGroup } from "@/generated/prisma/client"
+
+export type ChampionshipRegistrationProfile = Pick<
+    ChampionshipRegistration,
+    "name" | "membershipNo" | "competitorNumber" | "ageGroupId" | "categoryId" | "club" | "genderGroup"
+>
+
+export function participantDataFromRegistration(
+    registration: ChampionshipRegistrationProfile,
+    tournamentId: string
+) {
+    return {
+        tournamentId,
+        name: registration.name,
+        membershipNo: registration.membershipNo,
+        competitorNumber: registration.competitorNumber,
+        ageGroupId: registration.ageGroupId,
+        categoryId: registration.categoryId,
+        club: registration.club,
+        genderGroup: registration.genderGroup as GenderGroup,
+        checkedIn: false,
+    }
+}
+
+export function participantUpdateFromRegistration(registration: ChampionshipRegistrationProfile) {
+    return {
+        name: registration.name,
+        competitorNumber: registration.competitorNumber,
+        ageGroupId: registration.ageGroupId,
+        categoryId: registration.categoryId,
+        club: registration.club,
+        genderGroup: registration.genderGroup as GenderGroup,
+    }
+}

--- a/src/lib/participantProfileFields.ts
+++ b/src/lib/participantProfileFields.ts
@@ -1,0 +1,71 @@
+import type { ParticipantProfileInput } from "@/lib/participantProfileSchema"
+
+export type ParticipantProfileFieldKey = keyof ParticipantProfileInput
+
+export type ParticipantProfileFieldKind = "text" | "ageGroup" | "gender" | "category"
+
+export type ParticipantProfileFieldDefinition = {
+    key: ParticipantProfileFieldKey
+    label: string
+    placeholder?: string
+    kind: ParticipantProfileFieldKind
+}
+
+export const participantProfileFields: ParticipantProfileFieldDefinition[] = [
+    { key: "name", label: "Archer's name", placeholder: "Archer's name", kind: "text" },
+    { key: "membershipNo", label: "Membership number", placeholder: "Membership no.", kind: "text" },
+    { key: "club", label: "Club", placeholder: "Club", kind: "text" },
+    { key: "ageGroupId", label: "Age division", kind: "ageGroup" },
+    { key: "genderGroup", label: "Gender", kind: "gender" },
+    { key: "categoryId", label: "Equipment category", kind: "category" },
+]
+
+export const participantProfileFieldKeys = participantProfileFields.map((field) => field.key)
+
+export const participantProfileFieldGroups: ParticipantProfileFieldKey[][] = [
+    ["name", "membershipNo", "club"],
+    ["ageGroupId", "genderGroup", "categoryId"],
+]
+
+const fieldDefinitionByKey = Object.fromEntries(
+    participantProfileFields.map((field) => [field.key, field])
+) as Record<ParticipantProfileFieldKey, ParticipantProfileFieldDefinition>
+
+export function getParticipantProfileFieldDefinition(key: ParticipantProfileFieldKey) {
+    return fieldDefinitionByKey[key]
+}
+
+export function participantProfileFromFormData(formData: FormData): Record<ParticipantProfileFieldKey, FormDataEntryValue | null> {
+    return Object.fromEntries(
+        participantProfileFieldKeys.map((key) => [key, formData.get(key)])
+    ) as Record<ParticipantProfileFieldKey, FormDataEntryValue | null>
+}
+
+export function participantProfileFromParticipant(
+    participant: Partial<Record<ParticipantProfileFieldKey, string | null | undefined>> & {
+        genderGroup?: ParticipantProfileInput["genderGroup"] | null
+    }
+): Partial<ParticipantProfileInput> {
+    const profile: Partial<ParticipantProfileInput> = {}
+
+    if (participant.name) {
+        profile.name = participant.name
+    }
+    if (participant.membershipNo) {
+        profile.membershipNo = participant.membershipNo
+    }
+    if (participant.club) {
+        profile.club = participant.club
+    }
+    if (participant.ageGroupId) {
+        profile.ageGroupId = participant.ageGroupId
+    }
+    if (participant.categoryId) {
+        profile.categoryId = participant.categoryId
+    }
+    if (participant.genderGroup === "F" || participant.genderGroup === "M") {
+        profile.genderGroup = participant.genderGroup
+    }
+
+    return profile
+}


### PR DESCRIPTION
## Summary
- Enroll and unenroll championship competitors per day from the roster table (checkboxes, enroll-all per day, enroll-all on all days).
- Edit competitors on the championship roster and sync enrolled day participants; hide tournament add/edit/import on championship-linked day tournaments.
- Centralize participant profile fields and validation across tournament and championship forms; mark ADR M8 complete (v1.4.4).

## Test plan
- [ ] Register competitors on a championship and enroll/unenroll per day from the roster checkboxes
- [ ] Use “Enroll all” on a single day and “Enroll all on all days” with multiple roster entries
- [ ] Edit a roster competitor and confirm enrolled day participants update (name, membership no, profile fields)
- [ ] Open a championship-linked tournament day: add/edit/import hidden, notice links to championship roster
- [ ] Run unit tests: `championshipActions`, `championshipEnrollment`, `participantProfileFields`


Made with [Cursor](https://cursor.com)