### PR TITLE
M9: Combined championship standings

### DIFF
--- a/docs/architecture/ADR-0001-championships-multi-day.md
+++ b/docs/architecture/ADR-0001-championships-multi-day.md
@@ -227,7 +227,7 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - **Championship bib:** `competitorNumber` on `ChampionshipRegistration`, assigned at roster registration (`max + 1` within the championship), immutable, copied to each enrolled day’s `Participant`.
 - **Display name** in combined views: `ChampionshipRegistration.name` (source of truth at registration); enrolled day `Participant.name` is a copy at enroll time.
 
-### M9 — Combined standings (organizer view)
+### M9 — Combined standings (organizer view) ✓
 - Combined standings library and actions (sum raw scores, current tie semantics; `membershipNo` identity).
 - Championship detail section: combined standings table (updates as day scores are entered).
 - **UI test:** two days with enrolled competitors and scores → combined standings on championship detail match manual calculation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-comp",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/championships/[cId]/ChampionshipCombinedStandingsView.tsx
+++ b/src/app/championships/[cId]/ChampionshipCombinedStandingsView.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import type { ChampionshipCombinedStandings } from "@/lib/championshipCombinedStandings"
+import { championshipDetailContentClass } from "./championshipDetailLayout"
+
+function CategoryStandingsTable({
+    heading,
+    bgColor,
+    days,
+    competitors,
+}: {
+    heading: string
+    bgColor: string
+    days: ChampionshipCombinedStandings["days"]
+    competitors: ChampionshipCombinedStandings["complete"][number]["competitors"]
+}) {
+    return (
+        <div className={`${bgColor} rounded-lg p-3 mb-3`}>
+            <h3 className="text-base font-semibold mb-2">{heading}</h3>
+            <div className="overflow-x-auto">
+                <table className="table table-compact table-zebra w-full">
+                    <thead>
+                        <tr>
+                            <th className="w-12">Place</th>
+                            <th className="w-12">#</th>
+                            <th>Name</th>
+                            <th className="hidden md:table-cell">Club</th>
+                            {days.map((day) => (
+                                <th key={day.dayOrder} className="text-center">
+                                    D{day.dayOrder}
+                                </th>
+                            ))}
+                            <th className="text-right">Total</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {competitors.map((competitor) => (
+                            <tr key={competitor.membershipNo}>
+                                <td className="font-mono text-sm">{competitor.place ?? "—"}</td>
+                                <td className="font-mono text-sm">{competitor.competitorNumber}</td>
+                                <td>
+                                    <p className="font-medium text-sm">{competitor.name}</p>
+                                    <p className="text-xs text-base-content/70 md:hidden">{competitor.club}</p>
+                                </td>
+                                <td className="hidden md:table-cell text-sm">{competitor.club}</td>
+                                {days.map((day, index) => (
+                                    <td key={day.dayOrder} className="font-mono text-sm text-center">
+                                        {competitor.dayScoreLabels[index] ?? ""}
+                                    </td>
+                                ))}
+                                <td className="font-mono text-sm font-semibold text-right">
+                                    {competitor.totalLabel}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}
+
+export default function ChampionshipCombinedStandingsView({
+    standings,
+}: {
+    standings: ChampionshipCombinedStandings
+}) {
+    return (
+        <section className={championshipDetailContentClass}>
+            <h2 className="text-lg font-semibold mb-3">Combined standings</h2>
+            <p className="text-sm text-base-content/70 mb-4">
+                Totals sum completed day scores for enrolled competitors. DNC and DNF days do not add to the total.
+            </p>
+            {standings.inProgress.map((group) => (
+                <CategoryStandingsTable
+                    key={group.categoryKey}
+                    heading={group.heading}
+                    bgColor="bg-warning/10"
+                    days={standings.days}
+                    competitors={group.competitors}
+                />
+            ))}
+            {standings.complete.map((group) => (
+                <CategoryStandingsTable
+                    key={group.categoryKey}
+                    heading={group.heading}
+                    bgColor="bg-success/10"
+                    days={standings.days}
+                    competitors={group.competitors}
+                />
+            ))}
+            {standings.isEmpty ? (
+                <p className="text-sm text-base-content/60">No competitors registered yet.</p>
+            ) : null}
+        </section>
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipDetailHeader.tsx
+++ b/src/app/championships/[cId]/ChampionshipDetailHeader.tsx
@@ -1,0 +1,39 @@
+import { competitorsRegisteredLabel } from "../competitorsRegisteredLabel"
+import ChampionshipNameEdit from "./ChampionshipNameEdit"
+
+export default function ChampionshipDetailHeader({
+    championshipId,
+    name,
+    organizerClub,
+    registrationCount,
+    isArchive,
+    readOnly,
+}: {
+    championshipId: string
+    name: string
+    organizerClub: string
+    registrationCount: number
+    isArchive: boolean
+    readOnly: boolean
+}) {
+    return (
+        <>
+            <div className="flex flex-wrap items-baseline justify-between gap-2 mb-6">
+                <ChampionshipNameEdit
+                    championshipId={championshipId}
+                    initialName={name}
+                    readOnly={readOnly}
+                />
+                <div className="flex flex-wrap gap-2">
+                    {isArchive ? (
+                        <span className="badge badge-lg badge-warning">Archived</span>
+                    ) : null}
+                    <span className="badge badge-lg badge-info badge-outline">{organizerClub}</span>
+                </div>
+            </div>
+            <p className="text-sm text-base-content/70 mb-4">
+                {competitorsRegisteredLabel(registrationCount)}.
+            </p>
+        </>
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipNavigation.tsx
+++ b/src/app/championships/[cId]/ChampionshipNavigation.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { ChartBarIcon, Squares2X2Icon } from "@heroicons/react/24/outline"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+const activeTabClass =
+    "tab-active bg-primary text-primary-content border-secondary border-solid border-1 border-b-0"
+
+export default function ChampionshipNavigation({ championshipId }: { championshipId: string }) {
+    const pathname = usePathname()
+    const basePath = `/championships/${championshipId}`
+
+    const navItems = [
+        {
+            href: basePath,
+            label: "Overview",
+            icon: Squares2X2Icon,
+            isActive: pathname === basePath || pathname === `${basePath}/`,
+        },
+        {
+            href: `${basePath}/standings`,
+            label: "Combined standings",
+            icon: ChartBarIcon,
+            isActive:
+                pathname === `${basePath}/standings` ||
+                pathname.startsWith(`${basePath}/standings/`),
+        },
+    ]
+
+    return (
+        <div className="tabs tabs-boxed bg-base-200 mb-0">
+            {navItems.map((item) => {
+                const Icon = item.icon
+                return (
+                    <Link
+                        key={item.href}
+                        href={item.href}
+                        className={`tab flex items-center gap-2 min-w-0 flex-1 justify-center ${
+                            item.isActive ? activeTabClass : "hover:bg-base-300"
+                        }`}
+                    >
+                        <Icon className="w-4 h-4 shrink-0" />
+                        <span className="hidden md:block whitespace-nowrap">{item.label}</span>
+                    </Link>
+                )
+            })}
+        </div>
+    )
+}

--- a/src/app/championships/[cId]/layout.tsx
+++ b/src/app/championships/[cId]/layout.tsx
@@ -1,0 +1,47 @@
+import UnauthorizedChampionshipOrganizer from "@/components/UnauthorizedChampionshipOrganizer"
+import {
+    getChampionshipOrganizerClubs,
+    hasChampionshipOrganizerAccess,
+} from "@/lib/championshipOrganizerScope"
+import { notFound } from "next/navigation"
+import { auth } from "../../auth"
+import { getChampionshipForOrganizer } from "../championshipActions"
+import ChampionshipDetailHeader from "./ChampionshipDetailHeader"
+import ChampionshipNavigation from "./ChampionshipNavigation"
+
+export default async function ChampionshipDetailLayout({
+    children,
+    params,
+}: {
+    children: React.ReactNode
+    params: Promise<{ cId: string }>
+}) {
+    const session = await auth()
+
+    if (!session || !hasChampionshipOrganizerAccess(session.organizerRoles)) {
+        return <UnauthorizedChampionshipOrganizer />
+    }
+
+    const { cId } = await params
+    const clubs = getChampionshipOrganizerClubs(session.organizerRoles)
+    const championship = await getChampionshipForOrganizer(cId, clubs)
+
+    if (!championship) {
+        notFound()
+    }
+
+    return (
+        <div className="w-full min-h-max p-4">
+            <ChampionshipDetailHeader
+                championshipId={championship.id}
+                name={championship.name}
+                organizerClub={championship.organizerClub}
+                registrationCount={championship._count.registrations}
+                isArchive={championship.isArchive}
+                readOnly={championship.isArchive}
+            />
+            <ChampionshipNavigation championshipId={championship.id} />
+            <div className="border border-secondary border-solid w-full min-h-max">{children}</div>
+        </div>
+    )
+}

--- a/src/app/championships/[cId]/page.tsx
+++ b/src/app/championships/[cId]/page.tsx
@@ -1,25 +1,19 @@
-import UnauthorizedChampionshipOrganizer from "@/components/UnauthorizedChampionshipOrganizer"
-import {
-    getChampionshipOrganizerClubs,
-    hasChampionshipOrganizerAccess,
-} from "@/lib/championshipOrganizerScope"
-import { auth } from "../../auth"
+import { getChampionshipOrganizerClubs } from "@/lib/championshipOrganizerScope"
 import { notFound } from "next/navigation"
+import { auth } from "../../auth"
 import {
     getChampionshipForOrganizer,
     listChampionshipDayEnrollmentByTournament,
 } from "../championshipActions"
-import { competitorsRegisteredLabel } from "../competitorsRegisteredLabel"
+import { buildEnrollmentByMembership } from "@/lib/championshipEnrollment"
 import ChampionshipDaysSection from "./ChampionshipDaysSection"
-import ChampionshipNameEdit from "./ChampionshipNameEdit"
 import ChampionshipRosterSection from "./ChampionshipRosterSection"
 import type { ChampionshipRegistrationRow } from "./ChampionshipRosterList"
 
 export default async function ChampionshipDetailPage({ params }: { params: Promise<{ cId: string }> }) {
     const session = await auth()
-
-    if (!session || !hasChampionshipOrganizerAccess(session.organizerRoles)) {
-        return <UnauthorizedChampionshipOrganizer />
+    if (!session) {
+        notFound()
     }
 
     const { cId } = await params
@@ -38,13 +32,7 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
         label: round.tournament.name,
     }))
 
-    const enrollmentByMembership: Record<string, number[]> = {}
-    for (const round of championship.rounds) {
-        for (const membershipNo of enrollmentByTournament[round.tournamentId] ?? []) {
-            enrollmentByMembership[membershipNo] ??= []
-            enrollmentByMembership[membershipNo].push(round.dayOrder)
-        }
-    }
+    const enrollmentByMembership = buildEnrollmentByMembership(championship.rounds, enrollmentByTournament)
 
     const rounds = championship.rounds.map((round) => ({
         id: round.id,
@@ -70,23 +58,7 @@ export default async function ChampionshipDetailPage({ params }: { params: Promi
     }))
 
     return (
-        <div className="w-full p-4">
-            <div className="flex flex-wrap items-baseline justify-between gap-2 mb-6">
-                <ChampionshipNameEdit
-                    championshipId={championship.id}
-                    initialName={championship.name}
-                    readOnly={championship.isArchive}
-                />
-                <div className="flex flex-wrap gap-2">
-                    {championship.isArchive ? (
-                        <span className="badge badge-lg badge-warning">Archived</span>
-                    ) : null}
-                    <span className="badge badge-lg badge-info badge-outline">{championship.organizerClub}</span>
-                </div>
-            </div>
-            <p className="text-sm text-base-content/70 mb-2">
-                {competitorsRegisteredLabel(championship._count.registrations)}.
-            </p>
+        <div className="p-4 space-y-8">
             <ChampionshipDaysSection
                 championshipId={championship.id}
                 championshipName={championship.name}

--- a/src/app/championships/[cId]/standings/page.tsx
+++ b/src/app/championships/[cId]/standings/page.tsx
@@ -1,0 +1,26 @@
+import { getChampionshipOrganizerClubs } from "@/lib/championshipOrganizerScope"
+import { notFound } from "next/navigation"
+import { auth } from "../../../auth"
+import { getChampionshipCombinedStandings } from "../../championshipActions"
+import ChampionshipCombinedStandingsView from "../ChampionshipCombinedStandingsView"
+
+export default async function ChampionshipStandingsPage({ params }: { params: Promise<{ cId: string }> }) {
+    const session = await auth()
+    if (!session) {
+        notFound()
+    }
+
+    const { cId } = await params
+    const clubs = getChampionshipOrganizerClubs(session.organizerRoles)
+    const standings = await getChampionshipCombinedStandings(cId, clubs)
+
+    if (!standings) {
+        notFound()
+    }
+
+    return (
+        <div className="p-4">
+            <ChampionshipCombinedStandingsView standings={standings} />
+        </div>
+    )
+}

--- a/src/app/championships/championshipActions.ts
+++ b/src/app/championships/championshipActions.ts
@@ -4,7 +4,15 @@ import { revalidatePath } from "next/cache"
 import { Prisma } from "@/generated/prisma/client"
 import { championshipDayTournamentName, nextChampionshipDayOrder } from "@/lib/championshipDayNaming"
 import { assertChampionshipOrganizerClubs, resolveChampionshipOrganizerClubs } from "@/lib/championshipOrganizerSession"
-import { participantDataFromRegistration, participantUpdateFromRegistration } from "@/lib/championshipEnrollment"
+import {
+    buildEnrollmentByMembership,
+    participantDataFromRegistration,
+    participantUpdateFromRegistration,
+} from "@/lib/championshipEnrollment"
+import {
+    calculateChampionshipCombinedStandings,
+    type ChampionshipCombinedStandings,
+} from "@/lib/championshipCombinedStandings"
 import { prismaOrThrow } from "@/lib/prisma"
 
 export interface ChampionshipCreateInput {
@@ -487,19 +495,13 @@ export async function listChampionshipEnrolledMembershipNos(
     return [...new Set(Object.values(byTournament).flat())]
 }
 
-export async function listChampionshipDayEnrollmentByTournament(
-    championshipId: string,
-    organizerClubs: string[]
+async function listChampionshipDayEnrollmentByTournamentForChampionship(
+    championship: ChampionshipShellRow
 ): Promise<Record<string, string[]> | null> {
-    const championship = await getChampionshipForOrganizer(championshipId, organizerClubs)
-    if (!championship) {
-        return null
-    }
-
     const participants = await prismaOrThrow("list championship day enrollments").participant.findMany({
         where: {
             tournament: {
-                championshipRound: { championshipId },
+                championshipRound: { championshipId: championship.id },
             },
         },
         select: { membershipNo: true, tournamentId: true },
@@ -524,6 +526,97 @@ export async function listChampionshipDayEnrollmentByTournament(
     }
 
     return byTournament
+}
+
+export async function listChampionshipDayEnrollmentByTournament(
+    championshipId: string,
+    organizerClubs: string[]
+): Promise<Record<string, string[]> | null> {
+    const championship = await getChampionshipForOrganizer(championshipId, organizerClubs)
+    if (!championship) {
+        return null
+    }
+
+    return listChampionshipDayEnrollmentByTournamentForChampionship(championship)
+}
+
+async function listChampionshipDayScoresForChampionship(
+    championship: ChampionshipShellRow
+): Promise<{ tournamentId: string; membershipNo: string; rawScore: number | null }[] | null> {
+    const tournamentIds = championship.rounds.map((round) => round.tournamentId)
+    if (tournamentIds.length === 0) {
+        return []
+    }
+
+    const participants = await prismaOrThrow("list championship day scores").participant.findMany({
+        where: { tournamentId: { in: tournamentIds } },
+        select: {
+            membershipNo: true,
+            tournamentId: true,
+            participantScore: { select: { score: true } },
+        },
+    }).catch((error) => {
+        logAndReturnNull("Failed to list championship day scores", error)
+        return null
+    })
+
+    if (!participants) {
+        return null
+    }
+
+    return participants.map((participant) => ({
+        tournamentId: participant.tournamentId,
+        membershipNo: participant.membershipNo,
+        rawScore: participant.participantScore
+            ? Number(participant.participantScore.score)
+            : null,
+    }))
+}
+
+export async function getChampionshipCombinedStandings(
+    championshipId: string,
+    organizerClubs: string[]
+): Promise<ChampionshipCombinedStandings | null> {
+    const championship = await getChampionshipForOrganizer(championshipId, organizerClubs)
+    if (!championship) {
+        return null
+    }
+
+    const [enrollmentByTournament, scores] = await Promise.all([
+        listChampionshipDayEnrollmentByTournamentForChampionship(championship),
+        listChampionshipDayScoresForChampionship(championship),
+    ])
+
+    if (!enrollmentByTournament || !scores) {
+        return null
+    }
+
+    const days = championship.rounds.map((round) => ({
+        dayOrder: round.dayOrder,
+        tournamentId: round.tournamentId,
+        label: round.tournament.name,
+    }))
+
+    const registrations = championship.registrations.map((registration) => ({
+        membershipNo: registration.membershipNo,
+        competitorNumber: registration.competitorNumber,
+        name: registration.name,
+        club: registration.club,
+        ageGroupId: registration.ageGroupId,
+        categoryId: registration.categoryId,
+        genderGroup: registration.genderGroup,
+        ageGroupName: registration.ageGroup.name,
+        categoryName: registration.category.name,
+    }))
+
+    const enrollmentByMembership = buildEnrollmentByMembership(championship.rounds, enrollmentByTournament)
+
+    return calculateChampionshipCombinedStandings(
+        registrations,
+        days,
+        scores,
+        enrollmentByMembership
+    )
 }
 
 async function getWritableChampionshipShell(championshipId: string): Promise<ChampionshipShellRow> {

--- a/src/app/results/[rId]/TournamentResultsView.tsx
+++ b/src/app/results/[rId]/TournamentResultsView.tsx
@@ -1,17 +1,10 @@
 "use client"
 
 import MedalIcon from "@/app/tournaments/[tId]/components/MedalIcon"
-import { ParticipantResult } from "@/lib/scoreUtils"
+import { formatParticipantResultDisplay } from "@/lib/scoreUtils"
 import React from "react"
 import { ParticipantResultData, TournamentResultsData } from "../resultsActions"
 import ExportButton from "./components/ExportButton"
-
-function getDisplayValue(result: ParticipantResult): string {
-    if (result.status === 'DNF') return 'DNF'
-    if (result.status === 'DNC') return 'DNC'
-    if (result.shootoff !== null) return `${result.score} (${result.shootoff})`
-    return result.score?.toString() ?? ''
-}
 
 interface TournamentResultsViewProps {
     tournamentData: TournamentResultsData
@@ -67,7 +60,7 @@ const ParticipantRow = ({ participant, place }: { participant: ParticipantResult
             </td>
             <td>
                 <span className={`font-mono text-xs font-semibold ${isSpecial ? 'text-warning' : ''}`}>
-                    {getDisplayValue(participant.result)}
+                    {formatParticipantResultDisplay(participant.result)}
                 </span>
             </td>
         </tr>

--- a/src/app/tournaments/[tId]/scores/CategoryParticipantTableRow.tsx
+++ b/src/app/tournaments/[tId]/scores/CategoryParticipantTableRow.tsx
@@ -2,6 +2,7 @@
 
 import MedalIcon from "../components/MedalIcon"
 import ScoreInput from "../components/ScoreInput"
+import { formatParticipantResultDisplay } from "@/lib/scoreUtils"
 import { ParticipantWithResult } from "../scoreActions"
 
 export interface ParticipantWithPlace extends ParticipantWithResult {
@@ -10,14 +11,6 @@ export interface ParticipantWithPlace extends ParticipantWithResult {
     category: string
     categoryComplete: boolean
     hasUnresolvedTie: boolean
-}
-
-function getDisplayValue(result: ParticipantWithResult["result"]): string {
-    if (!result) return "-"
-    if (result.status === "DNF") return "DNF"
-    if (result.status === "DNC") return "DNC"
-    if (result.shootoff !== null) return `${result.score} (${result.shootoff})`
-    return result.score?.toString() ?? ""
 }
 
 export default function CategoryParticipantTableRow({ participant }: { participant: ParticipantWithPlace }) {
@@ -49,7 +42,7 @@ export default function CategoryParticipantTableRow({ participant }: { participa
                 <span className="text-sm">{participant.club || "Independent"}</span>
             </td>
             <td className="hidden md:table-cell">
-                <span className="font-mono text-sm">{getDisplayValue(participant.result)}</span>
+                <span className="font-mono text-sm">{formatParticipantResultDisplay(participant.result)}</span>
             </td>
             <td>
                 <ScoreInput participantId={participant.id} currentResult={participant.result} />

--- a/src/lib/__tests__/championshipCombinedStandings.test.ts
+++ b/src/lib/__tests__/championshipCombinedStandings.test.ts
@@ -1,0 +1,142 @@
+import {
+    buildCombinedStandingsRows,
+    compareCombinedStandingsRows,
+    formatCombinedTotal,
+    groupCombinedStandingsByCategory,
+} from "@/lib/championshipCombinedStandings"
+import { SCORE_DNC, toScore } from "@/lib/scoreUtils"
+
+describe("championshipCombinedStandings", () => {
+    const days = [
+        { dayOrder: 1, tournamentId: "t1", label: "Day 1" },
+        { dayOrder: 2, tournamentId: "t2", label: "Day 2" },
+    ]
+
+    const registrations = [
+        {
+            membershipNo: "M-001",
+            competitorNumber: 1,
+            name: "Alex",
+            club: "Club A",
+            ageGroupId: "age-1",
+            categoryId: "cat-1",
+            genderGroup: "M",
+            ageGroupName: "Adult",
+            categoryName: "Barebow",
+        },
+        {
+            membershipNo: "M-002",
+            competitorNumber: 2,
+            name: "Blair",
+            club: "Club B",
+            ageGroupId: "age-1",
+            categoryId: "cat-1",
+            genderGroup: "M",
+            ageGroupName: "Adult",
+            categoryName: "Barebow",
+        },
+    ]
+
+    const enrollmentByMembership = {
+        "M-001": [1, 2],
+        "M-002": [1, 2],
+    }
+
+    it("sums completed day scores across enrolled days", () => {
+        const rows = buildCombinedStandingsRows(
+            registrations,
+            days,
+            [
+                { tournamentId: "t1", membershipNo: "M-001", rawScore: 290 },
+                { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
+                { tournamentId: "t1", membershipNo: "M-002", rawScore: 280 },
+                { tournamentId: "t2", membershipNo: "M-002", rawScore: 285 },
+            ],
+            enrollmentByMembership
+        )
+
+        const alex = rows.find((row) => row.membershipNo === "M-001")
+        const blair = rows.find((row) => row.membershipNo === "M-002")
+
+        expect(alex?.total).toBe(585)
+        expect(blair?.total).toBe(565)
+        expect(alex?.isComplete).toBe(true)
+    })
+
+    it("includes shootoff decimals in the total", () => {
+        const rows = buildCombinedStandingsRows(
+            [registrations[0]],
+            days,
+            [
+                { tournamentId: "t1", membershipNo: "M-001", rawScore: toScore(290, 500) },
+                { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
+            ],
+            enrollmentByMembership
+        )
+
+        expect(rows[0]?.total).toBeCloseTo(290.5 + 295, 5)
+    })
+
+    it("does not add DNC to the combined total", () => {
+        const rows = buildCombinedStandingsRows(
+            [registrations[0]],
+            days,
+            [
+                { tournamentId: "t1", membershipNo: "M-001", rawScore: SCORE_DNC },
+                { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
+            ],
+            enrollmentByMembership
+        )
+
+        expect(rows[0]?.total).toBe(295)
+        expect(rows[0]?.isComplete).toBe(true)
+    })
+
+    it("marks not enrolled days and pending scores", () => {
+        const rows = buildCombinedStandingsRows(
+            [registrations[0]],
+            days,
+            [{ tournamentId: "t1", membershipNo: "M-001", rawScore: 290 }],
+            { "M-001": [1] }
+        )
+
+        expect(rows[0]?.dayScores[1]).toEqual({
+            kind: "scored",
+            rawScore: 290,
+            result: { status: "COMPLETED", score: 290, shootoff: null },
+        })
+        expect(rows[0]?.dayScores[2]).toEqual({ kind: "not_enrolled" })
+        expect(rows[0]?.isComplete).toBe(true)
+    })
+
+    it("sorts complete rows by total then name", () => {
+        const rows = buildCombinedStandingsRows(
+            registrations,
+            days,
+            [
+                { tournamentId: "t1", membershipNo: "M-001", rawScore: 290 },
+                { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
+                { tournamentId: "t1", membershipNo: "M-002", rawScore: 280 },
+                { tournamentId: "t2", membershipNo: "M-002", rawScore: 285 },
+            ],
+            enrollmentByMembership
+        )
+
+        const sorted = [...rows].sort(compareCombinedStandingsRows)
+        expect(sorted.map((row) => row.membershipNo)).toEqual(["M-001", "M-002"])
+    })
+
+    it("groups rows by category", () => {
+        const categories = groupCombinedStandingsByCategory(
+            buildCombinedStandingsRows(registrations, days, [], enrollmentByMembership)
+        )
+
+        expect(categories).toHaveLength(1)
+        expect(categories[0]?.rows).toHaveLength(2)
+    })
+
+    it("formats totals without trailing zeros", () => {
+        expect(formatCombinedTotal(585)).toBe("585")
+        expect(formatCombinedTotal(585.5)).toBe("585.5")
+    })
+})

--- a/src/lib/__tests__/championshipCombinedStandings.test.ts
+++ b/src/lib/__tests__/championshipCombinedStandings.test.ts
@@ -1,8 +1,6 @@
 import {
-    buildCombinedStandingsRows,
-    compareCombinedStandingsRows,
-    formatCombinedTotal,
-    groupCombinedStandingsByCategory,
+    calculateChampionshipCombinedStandings,
+    championshipCategoryKey,
 } from "@/lib/championshipCombinedStandings"
 import { SCORE_DNC, toScore } from "@/lib/scoreUtils"
 
@@ -42,29 +40,31 @@ describe("championshipCombinedStandings", () => {
         "M-002": [1, 2],
     }
 
+    function calculate(
+        scores: { tournamentId: string; membershipNo: string; rawScore: number | null }[],
+        enrollment = enrollmentByMembership
+    ) {
+        return calculateChampionshipCombinedStandings(registrations, days, scores, enrollment)
+    }
+
     it("sums completed day scores across enrolled days", () => {
-        const rows = buildCombinedStandingsRows(
-            registrations,
-            days,
-            [
-                { tournamentId: "t1", membershipNo: "M-001", rawScore: 290 },
-                { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
-                { tournamentId: "t1", membershipNo: "M-002", rawScore: 280 },
-                { tournamentId: "t2", membershipNo: "M-002", rawScore: 285 },
-            ],
-            enrollmentByMembership
-        )
+        const standings = calculate([
+            { tournamentId: "t1", membershipNo: "M-001", rawScore: 290 },
+            { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
+            { tournamentId: "t1", membershipNo: "M-002", rawScore: 280 },
+            { tournamentId: "t2", membershipNo: "M-002", rawScore: 285 },
+        ])
 
-        const alex = rows.find((row) => row.membershipNo === "M-001")
-        const blair = rows.find((row) => row.membershipNo === "M-002")
+        const competitors = standings?.complete[0]?.competitors ?? []
+        const alex = competitors.find((entry) => entry.membershipNo === "M-001")
+        const blair = competitors.find((entry) => entry.membershipNo === "M-002")
 
-        expect(alex?.total).toBe(585)
-        expect(blair?.total).toBe(565)
-        expect(alex?.isComplete).toBe(true)
+        expect(alex?.totalLabel).toBe("585")
+        expect(blair?.totalLabel).toBe("565")
     })
 
     it("includes shootoff decimals in the total", () => {
-        const rows = buildCombinedStandingsRows(
+        const standings = calculateChampionshipCombinedStandings(
             [registrations[0]],
             days,
             [
@@ -74,11 +74,11 @@ describe("championshipCombinedStandings", () => {
             enrollmentByMembership
         )
 
-        expect(rows[0]?.total).toBeCloseTo(290.5 + 295, 5)
+        expect(standings?.complete[0]?.competitors[0]?.totalLabel).toBe("585.5")
     })
 
     it("does not add DNC to the combined total", () => {
-        const rows = buildCombinedStandingsRows(
+        const standings = calculateChampionshipCombinedStandings(
             [registrations[0]],
             days,
             [
@@ -88,55 +88,56 @@ describe("championshipCombinedStandings", () => {
             enrollmentByMembership
         )
 
-        expect(rows[0]?.total).toBe(295)
-        expect(rows[0]?.isComplete).toBe(true)
+        expect(standings?.complete[0]?.competitors[0]?.totalLabel).toBe("295")
     })
 
-    it("marks not enrolled days and pending scores", () => {
-        const rows = buildCombinedStandingsRows(
+    it("labels not enrolled and pending days", () => {
+        const standings = calculateChampionshipCombinedStandings(
             [registrations[0]],
             days,
             [{ tournamentId: "t1", membershipNo: "M-001", rawScore: 290 }],
             { "M-001": [1] }
         )
 
-        expect(rows[0]?.dayScores[1]).toEqual({
-            kind: "scored",
-            rawScore: 290,
-            result: { status: "COMPLETED", score: 290, shootoff: null },
-        })
-        expect(rows[0]?.dayScores[2]).toEqual({ kind: "not_enrolled" })
-        expect(rows[0]?.isComplete).toBe(true)
+        const labels = standings?.complete[0]?.competitors[0]?.dayScoreLabels ?? []
+        expect(labels[0]).toBe("290")
+        expect(labels[1]).toBe("")
     })
 
-    it("sorts complete rows by total then name", () => {
-        const rows = buildCombinedStandingsRows(
-            registrations,
-            days,
-            [
-                { tournamentId: "t1", membershipNo: "M-001", rawScore: 290 },
-                { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
-                { tournamentId: "t1", membershipNo: "M-002", rawScore: 280 },
-                { tournamentId: "t2", membershipNo: "M-002", rawScore: 285 },
-            ],
-            enrollmentByMembership
-        )
+    it("sorts complete competitors by total then name", () => {
+        const standings = calculate([
+            { tournamentId: "t1", membershipNo: "M-001", rawScore: 290 },
+            { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
+            { tournamentId: "t1", membershipNo: "M-002", rawScore: 280 },
+            { tournamentId: "t2", membershipNo: "M-002", rawScore: 285 },
+        ])
 
-        const sorted = [...rows].sort(compareCombinedStandingsRows)
-        expect(sorted.map((row) => row.membershipNo)).toEqual(["M-001", "M-002"])
+        expect(standings?.complete[0]?.competitors.map((entry) => entry.membershipNo)).toEqual([
+            "M-001",
+            "M-002",
+        ])
     })
 
-    it("groups rows by category", () => {
-        const categories = groupCombinedStandingsByCategory(
-            buildCombinedStandingsRows(registrations, days, [], enrollmentByMembership)
-        )
+    it("groups competitors by category", () => {
+        const standings = calculate([])
 
-        expect(categories).toHaveLength(1)
-        expect(categories[0]?.rows).toHaveLength(2)
+        expect(standings?.inProgress).toHaveLength(1)
+        expect(standings?.inProgress[0]?.competitors).toHaveLength(2)
     })
 
-    it("formats totals without trailing zeros", () => {
-        expect(formatCombinedTotal(585)).toBe("585")
-        expect(formatCombinedTotal(585.5)).toBe("585.5")
+    it("builds category keys", () => {
+        expect(championshipCategoryKey("age-1", "M", "cat-1")).toBe("age-1Mcat-1")
+    })
+
+    it("assigns places only when category scoring is complete", () => {
+        const standings = calculate([
+            { tournamentId: "t1", membershipNo: "M-001", rawScore: 290 },
+            { tournamentId: "t2", membershipNo: "M-001", rawScore: 295 },
+            { tournamentId: "t1", membershipNo: "M-002", rawScore: 280 },
+            { tournamentId: "t2", membershipNo: "M-002", rawScore: 285 },
+        ])
+
+        expect(standings?.complete[0]?.competitors[0]?.place).toBe(1)
+        expect(standings?.inProgress).toHaveLength(0)
     })
 })

--- a/src/lib/championshipCombinedStandings.ts
+++ b/src/lib/championshipCombinedStandings.ts
@@ -1,0 +1,286 @@
+import {
+    formatParticipantResultDisplay,
+    toResult,
+    type ParticipantResult,
+} from "@/lib/scoreUtils"
+
+export type ChampionshipDay = {
+    dayOrder: number
+    tournamentId: string
+    label: string
+}
+
+export type RegisteredCompetitor = {
+    membershipNo: string
+    competitorNumber: number
+    name: string
+    club: string
+    ageGroupId: string
+    categoryId: string
+    genderGroup: string
+    ageGroupName: string
+    categoryName: string
+}
+
+export type DayScoreInput = {
+    tournamentId: string
+    membershipNo: string
+    rawScore: number | null
+}
+
+type DayScoreStatus =
+    | { kind: "not_enrolled" }
+    | { kind: "pending" }
+    | { kind: "scored"; rawScore: number; result: ParticipantResult }
+
+type CompetitorStanding = {
+    membershipNo: string
+    competitorNumber: number
+    name: string
+    club: string
+    ageGroupId: string
+    categoryId: string
+    genderGroup: string
+    categoryKey: string
+    categoryLabel: string
+    scoresByDay: Record<number, DayScoreStatus>
+    combinedTotal: number | null
+    scoringComplete: boolean
+}
+
+type CategoryStandings = {
+    categoryKey: string
+    categoryLabel: string
+    scoringComplete: boolean
+    competitors: CompetitorStanding[]
+}
+
+export type CompetitorStandingsEntry = {
+    membershipNo: string
+    competitorNumber: number
+    name: string
+    club: string
+    place: number | null
+    dayScoreLabels: string[]
+    totalLabel: string
+}
+
+export type CategoryStandingsGroup = {
+    categoryKey: string
+    heading: string
+    showPlaces: boolean
+    competitors: CompetitorStandingsEntry[]
+}
+
+export type ChampionshipCombinedStandings = {
+    days: { dayOrder: number; label: string }[]
+    inProgress: CategoryStandingsGroup[]
+    complete: CategoryStandingsGroup[]
+    isEmpty: boolean
+}
+
+export function championshipCategoryKey(
+    ageGroupId: string,
+    genderGroup: string,
+    categoryId: string
+): string {
+    return `${ageGroupId}${genderGroup}${categoryId}`
+}
+
+function formatStandingsTotal(total: number | null): string {
+    if (total === null) {
+        return "—"
+    }
+    return Number.isInteger(total) ? String(total) : total.toFixed(3).replace(/\.?0+$/, "")
+}
+
+function completedScoreContribution(rawScore: number): number | null {
+    const result = toResult(rawScore)
+    if (result.status !== "COMPLETED") {
+        return null
+    }
+    return rawScore
+}
+
+function sumCompletedDayTotals(scoresByDay: Record<number, DayScoreStatus>): number | null {
+    let total = 0
+    let hasContribution = false
+
+    for (const dayScore of Object.values(scoresByDay)) {
+        if (dayScore.kind !== "scored") {
+            continue
+        }
+        const contribution = completedScoreContribution(dayScore.rawScore)
+        if (contribution === null) {
+            continue
+        }
+        total += contribution
+        hasContribution = true
+    }
+
+    return hasContribution ? total : null
+}
+
+function resolveDayScoreStatus(
+    enrolledDayOrders: number[],
+    dayOrder: number,
+    rawScore: number | undefined
+): DayScoreStatus {
+    if (!enrolledDayOrders.includes(dayOrder)) {
+        return { kind: "not_enrolled" }
+    }
+    if (rawScore === undefined) {
+        return { kind: "pending" }
+    }
+    return { kind: "scored", rawScore, result: toResult(rawScore) }
+}
+
+function calculateCompetitorStandings(
+    registrations: RegisteredCompetitor[],
+    days: ChampionshipDay[],
+    scores: DayScoreInput[],
+    enrollmentByMembership: Record<string, number[]>
+): CompetitorStanding[] {
+    const tournamentDayOrder = new Map(days.map((day) => [day.tournamentId, day.dayOrder]))
+    const scoresByMembershipDay = new Map<string, Map<number, number>>()
+
+    for (const score of scores) {
+        const dayOrder = tournamentDayOrder.get(score.tournamentId)
+        if (dayOrder === undefined || score.rawScore === null) {
+            continue
+        }
+        const byDay = scoresByMembershipDay.get(score.membershipNo) ?? new Map()
+        byDay.set(dayOrder, score.rawScore)
+        scoresByMembershipDay.set(score.membershipNo, byDay)
+    }
+
+    return registrations.map((registration) => {
+        const enrolledDayOrders = enrollmentByMembership[registration.membershipNo] ?? []
+        const scoresForMember = scoresByMembershipDay.get(registration.membershipNo)
+        const scoresByDay: Record<number, DayScoreStatus> = {}
+
+        for (const day of days) {
+            scoresByDay[day.dayOrder] = resolveDayScoreStatus(
+                enrolledDayOrders,
+                day.dayOrder,
+                scoresForMember?.get(day.dayOrder)
+            )
+        }
+
+        const scoringComplete =
+            enrolledDayOrders.length > 0 &&
+            enrolledDayOrders.every((dayOrder) => scoresByDay[dayOrder]?.kind === "scored")
+
+        return {
+            membershipNo: registration.membershipNo,
+            competitorNumber: registration.competitorNumber,
+            name: registration.name,
+            club: registration.club,
+            ageGroupId: registration.ageGroupId,
+            categoryId: registration.categoryId,
+            genderGroup: registration.genderGroup,
+            categoryKey: championshipCategoryKey(
+                registration.ageGroupId,
+                registration.genderGroup,
+                registration.categoryId
+            ),
+            categoryLabel: `${registration.ageGroupName} ${registration.genderGroup} ${registration.categoryName}`,
+            scoresByDay,
+            combinedTotal: sumCompletedDayTotals(scoresByDay),
+            scoringComplete,
+        }
+    })
+}
+
+function compareCompetitorStandings(a: CompetitorStanding, b: CompetitorStanding): number {
+    if (a.scoringComplete !== b.scoringComplete) {
+        return a.scoringComplete ? 1 : -1
+    }
+
+    const aTotal = a.combinedTotal ?? 0
+    const bTotal = b.combinedTotal ?? 0
+    if (aTotal !== bTotal) {
+        return bTotal - aTotal
+    }
+
+    return a.name.localeCompare(b.name)
+}
+
+function groupStandingsByCategory(competitors: CompetitorStanding[]): CategoryStandings[] {
+    const grouped = new Map<string, CompetitorStanding[]>()
+
+    for (const competitor of competitors) {
+        const existing = grouped.get(competitor.categoryKey) ?? []
+        existing.push(competitor)
+        grouped.set(competitor.categoryKey, existing)
+    }
+
+    return [...grouped.entries()]
+        .map(([categoryKey, categoryCompetitors]) => {
+            const sortedCompetitors = [...categoryCompetitors].sort(compareCompetitorStandings)
+            return {
+                categoryKey,
+                categoryLabel: sortedCompetitors[0]?.categoryLabel ?? categoryKey,
+                scoringComplete: sortedCompetitors.every((competitor) => competitor.scoringComplete),
+                competitors: sortedCompetitors,
+            }
+        })
+        .sort((a, b) => a.categoryLabel.localeCompare(b.categoryLabel))
+}
+
+function formatDayScoreLabel(dayScore: DayScoreStatus | undefined): string {
+    if (dayScore?.kind === "scored") {
+        return formatParticipantResultDisplay(dayScore.result)
+    }
+    if (dayScore?.kind === "pending") {
+        return "—"
+    }
+    return ""
+}
+
+function formatCategoryStandingsGroup(
+    category: CategoryStandings,
+    days: ChampionshipDay[],
+    showPlaces: boolean
+): CategoryStandingsGroup {
+    return {
+        categoryKey: category.categoryKey,
+        heading: showPlaces ? category.categoryLabel : `${category.categoryLabel} — in progress`,
+        showPlaces,
+        competitors: category.competitors.map((competitor, index) => ({
+            membershipNo: competitor.membershipNo,
+            competitorNumber: competitor.competitorNumber,
+            name: competitor.name,
+            club: competitor.club,
+            place: showPlaces ? index + 1 : null,
+            dayScoreLabels: days.map((day) => formatDayScoreLabel(competitor.scoresByDay[day.dayOrder])),
+            totalLabel: formatStandingsTotal(competitor.combinedTotal),
+        })),
+    }
+}
+
+export function calculateChampionshipCombinedStandings(
+    registrations: RegisteredCompetitor[],
+    days: ChampionshipDay[],
+    scores: DayScoreInput[],
+    enrollmentByMembership: Record<string, number[]>
+): ChampionshipCombinedStandings | null {
+    if (days.length === 0) {
+        return null
+    }
+
+    const categories = groupStandingsByCategory(
+        calculateCompetitorStandings(registrations, days, scores, enrollmentByMembership)
+    )
+
+    return {
+        days: days.map((day) => ({ dayOrder: day.dayOrder, label: day.label })),
+        inProgress: categories
+            .filter((category) => !category.scoringComplete)
+            .map((category) => formatCategoryStandingsGroup(category, days, false)),
+        complete: categories
+            .filter((category) => category.scoringComplete)
+            .map((category) => formatCategoryStandingsGroup(category, days, true)),
+        isEmpty: categories.length === 0,
+    }
+}

--- a/src/lib/championshipEnrollment.ts
+++ b/src/lib/championshipEnrollment.ts
@@ -32,3 +32,19 @@ export function participantUpdateFromRegistration(registration: ChampionshipRegi
         genderGroup: registration.genderGroup as GenderGroup,
     }
 }
+
+export function buildEnrollmentByMembership(
+    rounds: { tournamentId: string; dayOrder: number }[],
+    enrollmentByTournament: Record<string, string[]>
+): Record<string, number[]> {
+    const enrollmentByMembership: Record<string, number[]> = {}
+
+    for (const round of rounds) {
+        for (const membershipNo of enrollmentByTournament[round.tournamentId] ?? []) {
+            enrollmentByMembership[membershipNo] ??= []
+            enrollmentByMembership[membershipNo].push(round.dayOrder)
+        }
+    }
+
+    return enrollmentByMembership
+}

--- a/src/lib/scoreUtils.ts
+++ b/src/lib/scoreUtils.ts
@@ -31,6 +31,22 @@ export function toScore(score: number, shootoff?: number): number {
     return score
 }
 
+export function formatParticipantResultDisplay(result: ParticipantResult | null): string {
+    if (!result) {
+        return "-"
+    }
+    if (result.status === "DNF") {
+        return "DNF"
+    }
+    if (result.status === "DNC") {
+        return "DNC"
+    }
+    if (result.shootoff !== null) {
+        return `${result.score} (${result.shootoff})`
+    }
+    return result.score?.toString() ?? "-"
+}
+
 export interface TiebreakerCandidate {
     participantId: string
     name: string


### PR DESCRIPTION
## Summary
- Add combined standings calculated on the server (`getChampionshipCombinedStandings`) with per-day scores, totals, and category grouping.
- Show standings on a dedicated championship tab (Overview | Combined standings), matching the tournament sub-page pattern.
- Centralize participant score display formatting in `scoreUtils.formatParticipantResultDisplay`.

This branch also includes prior M8 enrollment/roster work (not yet on `main`).

## Test plan
- [ ] Championship with 2+ days: enroll competitors, enter scores on each day, open Combined standings tab
- [ ] Verify totals match manual sum of completed day scores; DNC/DNF days excluded from total
- [ ] Incomplete categories appear under in progress; complete categories show places
- [ ] Standalone tournament score entry and public results still render scores correctly
- [ ] Run `npm test` (including `championshipCombinedStandings`)


Made with [Cursor](https://cursor.com)