### PR TITLE
feat(championships): M11 public championship results

### DIFF
--- a/docs/architecture/ADR-0001-championships-multi-day.md
+++ b/docs/architecture/ADR-0001-championships-multi-day.md
@@ -66,7 +66,7 @@ Championship access is **not** a separate role table. It is a **per-club upgrade
 
 ### Behavioral rules
 - Day 1 groups are manual within each range’s day-tournament (M10).
-- Day 2+ groups are auto-seeded from combined standings using adjacent blocks (M11):
+- Day 2+ groups are auto-seeded from combined standings using adjacent blocks (M12):
   - example (`groupSize=4`): `1-4`, `5-8`, `9-12`.
   - seeding **must respect ranges (M10):** seed only into the day-tournament for the range where that division is assigned for that day; never split a division across range tournaments.
 - Tail handling:
@@ -95,7 +95,7 @@ Organizers must be able to run a multi-day event end-to-end in the app without m
 4. **Assign divisions to ranges (M10)** — before the first day-1 enrollment, configure the category–range matrix (see shooting ranges). Required gate for enrollment.
 5. **Enroll into days** — per day and range: create `Participant` rows only on the day-tournament for that range when the competitor’s division is assigned to that range for that day.
 6. **Run each day** — from the championship detail, open tournament flows per range: participants, **groups**, **scores** (existing `/tournaments/[tId]` UI; one tournament per range).
-7. **Later milestones** — combined standings (M9 ✓), shooting ranges (M10), day 2+ auto-seed (M11), late join/drop (M12), optional public results (M13).
+7. **Later milestones** — combined standings (M9 ✓), shooting ranges (M10 ✓), public championship results (M11), day 2+ auto-seed (M12), late join/drop (M13).
 
 Day execution deliberately reuses the standalone tournament engine; the championship layer orchestrates identity, enrollment, and cross-day logic.
 
@@ -120,7 +120,7 @@ These are **different fields**; do not conflate them.
   - `Participant.competitorNumber` ← `ChampionshipRegistration.competitorNumber`
 - Profile edits at championship level update `ChampionshipRegistration`; re-enroll or sync rules for already-enrolled days are documented in the runbook (M14).
 - One `Participant` per `(tournamentId, membershipNo)` per range day-tournament; re-enroll on the same day/range is an update, not a duplicate.
-- Enrolling on day `N` without prior day rows does not auto-create participants on earlier days (late join / DNC backfill remains M12).
+- Enrolling on day `N` without prior day rows does not auto-create participants on earlier days (late join / DNC backfill remains M13).
 - Unenroll from a day/range: remove `Participant` (and dependent group/score rows) without removing `ChampionshipRegistration`.
 - **Unassign division from a range (M10):** automatically unenroll all roster members in that division from every day-tournament for that range (and from other ranges if the unassignment removes their only valid range for that day — product rule: unassigning a division from a range unenrolls all affected participants from day enrollments tied to that assignment).
 
@@ -153,7 +153,7 @@ These are **different fields**; do not conflate them.
 - **Groups / score by group:** unchanged within each range’s tournament (`/tournaments/[tId]`).
 - **Score by category**, **combined standings (M9)**, **public results**, **IFAF export:** aggregate across range tournaments for the day/championship; ranges are not surfaced (end-of-day scores only; IFAF export unchanged).
 
-**Auto-seed (M11):** must respect per-day division↔range assignments — seed into the correct range’s day-tournament only.
+**Auto-seed (M12):** must respect per-day division↔range assignments — seed into the correct range’s day-tournament only.
 
 **Migration:** existing championships behave as `rangeCount = 1`; each historical day gains a single round row with `rangeNumber = 1`. Update unique constraint on `ChampionshipRound` from `(championshipId, dayOrder)` to `(championshipId, dayOrder, rangeNumber)`.
 
@@ -223,7 +223,7 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - Championship CRUD + day attach/detach actions (`dayOrder` set at create; no reorder).
 - `registerChampionshipParticipant` (championship roster).
 - Enforce transactional integrity on `ChampionshipRound` creation/removal with linked tournament references.
-- Additional actions (day enrollment, combined standings, ranges, auto-seed, late join) ship with their UI milestone (M8, M9, M10, M11, M12).
+- Additional actions (day enrollment, combined standings, ranges, public results, auto-seed, late join) ship with their UI milestone (M8, M9, M10, M11, M12, M13).
 
 ### M3 — Standalone tournament list guardrail ✓
 - Default tournament list queries use `championshipRound IS NULL` (`standaloneTournamentWhere` in `listTournamentsForClubs` and results browse).
@@ -277,7 +277,7 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - Championship detail section: combined standings table (updates as day scores are entered).
 - **UI test:** two days with enrolled competitors and scores → combined standings on championship detail match manual calculation.
 
-### M10 — Championship shooting ranges (championship-only)
+### M10 — Championship shooting ranges (championship-only) ✓
 - Schema: `Championship.rangeCount`; `ChampionshipRound.rangeNumber`; `ChampionshipDivisionRange` (`championshipId`, `dayOrder`, division key, `rangeNumber`).
 - Create/edit championship: **number of ranges** (default 1). Standalone tournament create unchanged.
 - Add day: create **`rangeCount` day-tournaments** per day; hub lists day → range → tournament links.
@@ -287,22 +287,22 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - Combined standings / category scoring / IFAF: unchanged aggregation across range tournaments.
 - **UI test:** championship with 2 ranges and 2 divisions → matrix assign → enroll only on matching range day-tournament → day-1 score freezes matrix → day-2 move whole division to other range tournament → category standings still aggregate.
 
-### M11 — Day 2+ auto-seed
+### M11 — Public championship results (optional)
+- Public results route composing per-day and combined views.
+- Existing per-tournament publish/share unchanged.
+- **UI test:** publish/share championship results URL → spectator sees per-day and combined tables.
+
+### M12 — Day 2+ auto-seed
 - Auto-seed from combined standings (adjacent blocks + tail rebalance).
 - **Must respect ranges (M10):** seed into the day-tournament for each division’s assigned range for that `dayOrder`; never split a division across range tournaments.
 - Organizer control on championship detail or day tournament: run auto-seed for a day before/at group setup.
 - Post-seed editing remains in existing `/tournaments/[tId]/groups` UI.
 - **UI test:** enter day 1 scores → run auto-seed for day 2 → open day 2 groups → groups match seed rules and range rules → manual edit persists until re-seed.
 
-### M12 — Late join and drop
+### M13 — Late join and drop
 - Late join: register at championship level if needed, enroll on day `N`, prior-day DNC backfill for days `< N`.
 - Drop: unenroll or mark inactive on later days; bulk DNC on remaining days (no automatic DNC on drop alone).
 - **UI test:** late join on day 2 → prior day shows DNC → drop with bulk DNC on day 3+ only when action run.
-
-### M13 — Public championship results (optional)
-- Public results route composing per-day and combined views.
-- Existing per-tournament publish/share unchanged.
-- **UI test:** publish/share championship results URL → spectator sees per-day and combined tables.
 
 ### M14 — Hardening and runbook
 - Integration/regression coverage for M4–M13 paths.
@@ -324,9 +324,9 @@ M1–M5 are delivered in code (including Championship Organizer power-up on `Org
 - **M8:** enroll/unenroll on days; day `Participant` has registration `membershipNo` and registration `competitorNumber` (distinct fields).
 - **M9:** combined standings on championship detail match manual totals across days.
 - **M10:** championship `rangeCount`; one tournament per `(day, range)`; category–range matrix; enrollment gates; day-1 freeze; day-2+ whole-division range moves; standalone tournaments unchanged.
-- **M11:** day 2+ auto-seed produces correct groups in the correct range day-tournament; manual override in tournament groups UI works.
-- **M12:** late join backfills DNC; drop does not auto-DNC; bulk DNC action works.
-- **M13:** public championship results page shows per-day and combined views.
+- **M11:** public championship results page shows per-day and combined views.
+- **M12:** day 2+ auto-seed produces correct groups in the correct range day-tournament; manual override in tournament groups UI works.
+- **M13:** late join backfills DNC; drop does not auto-DNC; bulk DNC action works.
 - **M14:** runbook seed reproduces M4–M9 smoke path; documented standalone regression checklist passes.
 
 ## Decision diagram
@@ -341,7 +341,8 @@ flowchart TD
   dayTournament --> tournamentUI[ExistingTournamentUI_GroupsScores]
   dayTournament --> dayScores[ParticipantScore]
   dayScores --> combinedStandings[CombinedStandings]
-  combinedStandings --> seedDayN[AutoSeedDayN_respectsRange]
+  combinedStandings --> publicResults[PublicChampionshipResults_M11]
+  combinedStandings --> seedDayN[AutoSeedDayN_respectsRange_M12]
   seedDayN --> dayGroups[GroupAssignment]
   dayGroups --> manualEdits[OrganizerManualEdits]
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-comp",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/championships/[cId]/ChampionshipCombinedStandingsView.tsx
+++ b/src/app/championships/[cId]/ChampionshipCombinedStandingsView.tsx
@@ -98,18 +98,25 @@ function CategoryStandingsCard({
 
 export default function ChampionshipCombinedStandingsView({
     standings,
+    embedded = false,
 }: {
     standings: ChampionshipCombinedStandings
+    embedded?: boolean
 }) {
     const tableMinWidth = combinedStandingsMinWidth(standings.days.length)
     const allGroups = [...standings.inProgress, ...standings.complete]
 
     return (
-        <section className={championshipDetailContentClass}>
-            <h2 className="text-lg font-semibold mb-3">Combined standings</h2>
-            <p className="text-sm text-base-content/70 mb-4">
-                Totals sum completed day scores for enrolled competitors. DNC and DNF days do not add to the total.
-            </p>
+        <section className={embedded ? "w-full" : championshipDetailContentClass}>
+            {!embedded ? (
+                <>
+                    <h2 className="text-lg font-semibold mb-3">Combined standings</h2>
+                    <p className="text-sm text-base-content/70 mb-4">
+                        Totals sum completed day scores for enrolled competitors. DNC and DNF days do not add to the
+                        total.
+                    </p>
+                </>
+            ) : null}
             {allGroups.length > 0 ? (
                 <div className="overflow-x-auto">
                     <div className="space-y-3" style={{ minWidth: tableMinWidth }}>

--- a/src/app/championships/[cId]/ChampionshipDetailHeader.tsx
+++ b/src/app/championships/[cId]/ChampionshipDetailHeader.tsx
@@ -1,5 +1,6 @@
 import { competitorsRegisteredLabel } from "../competitorsRegisteredLabel"
 import ChampionshipNameEdit from "./ChampionshipNameEdit"
+import ChampionshipSharingButton from "./ChampionshipSharingButton"
 
 export default function ChampionshipDetailHeader({
     championshipId,
@@ -24,7 +25,10 @@ export default function ChampionshipDetailHeader({
                     initialName={name}
                     readOnly={readOnly}
                 />
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                    {!readOnly ? (
+                        <ChampionshipSharingButton championshipId={championshipId} readOnly={readOnly} />
+                    ) : null}
                     {isArchive ? (
                         <span className="badge badge-lg badge-warning">Archived</span>
                     ) : null}

--- a/src/app/championships/[cId]/ChampionshipSharingButton.tsx
+++ b/src/app/championships/[cId]/ChampionshipSharingButton.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { ShareIcon } from "@heroicons/react/24/outline"
+import { useState } from "react"
+import {
+    getChampionshipSharingStatus,
+    type ChampionshipSharingStatus,
+} from "../championshipActions"
+import ChampionshipSharingDrawer, { championshipSharingBadgeLabel } from "./ChampionshipSharingDrawer"
+
+export default function ChampionshipSharingButton({
+    championshipId,
+    readOnly,
+}: {
+    championshipId: string
+    readOnly: boolean
+}) {
+    const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+    const [sharingStatus, setSharingStatus] = useState<ChampionshipSharingStatus | null>(null)
+    const [isLoading, setIsLoading] = useState(false)
+
+    if (readOnly) {
+        return null
+    }
+
+    const badgeLabel = sharingStatus ? championshipSharingBadgeLabel(sharingStatus.sharingOption) : null
+
+    const handleOpen = async () => {
+        setIsLoading(true)
+        try {
+            const status = await getChampionshipSharingStatus(championshipId)
+            if (!status) {
+                return
+            }
+            setSharingStatus(status)
+            setIsDrawerOpen(true)
+        } catch (error) {
+            console.error("Failed to load championship sharing status:", error)
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
+    return (
+        <>
+            <button
+                type="button"
+                className="btn btn-primary btn-sm gap-1"
+                onClick={handleOpen}
+                disabled={isLoading}
+            >
+                <ShareIcon className="w-4 h-4" />
+                {isLoading ? "Loading..." : "Sharing"}
+                {badgeLabel ? <span className="badge badge-xs badge-secondary">{badgeLabel}</span> : null}
+            </button>
+            {sharingStatus ? (
+                <ChampionshipSharingDrawer
+                    championshipId={championshipId}
+                    isOpen={isDrawerOpen}
+                    onClose={() => setIsDrawerOpen(false)}
+                    sharingStatus={sharingStatus}
+                    onSharingUpdated={setSharingStatus}
+                />
+            ) : null}
+        </>
+    )
+}

--- a/src/app/championships/[cId]/ChampionshipSharingDrawer.tsx
+++ b/src/app/championships/[cId]/ChampionshipSharingDrawer.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import useErrorContext from "@/components/errors/ErrorContext"
+import {
+    flagsFromSharingOption,
+    type SharingOption,
+} from "@/lib/tournamentSharing"
+import { useEffect, useRef, useState } from "react"
+import {
+    getChampionshipSharingStatus,
+    updateChampionshipSharingSettings,
+    type ChampionshipSharingStatus,
+} from "../championshipActions"
+
+type SelectableSharingOption = Exclude<SharingOption, "mixed">
+
+function isSelectableSharingOption(option: SharingOption): option is SelectableSharingOption {
+    return option !== "mixed"
+}
+
+export default function ChampionshipSharingDrawer({
+    championshipId,
+    isOpen,
+    onClose,
+    sharingStatus,
+    onSharingUpdated,
+}: {
+    championshipId: string
+    isOpen: boolean
+    onClose: () => void
+    sharingStatus: ChampionshipSharingStatus
+    onSharingUpdated: (status: ChampionshipSharingStatus) => void
+}) {
+    const setError = useErrorContext()
+    const [isUpdating, setIsUpdating] = useState(false)
+    const [copied, setCopied] = useState(false)
+    const drawerCheckboxRef = useRef<HTMLInputElement>(null)
+    const [selectedOption, setSelectedOption] = useState<SelectableSharingOption>("private")
+
+    useEffect(() => {
+        if (drawerCheckboxRef.current) {
+            drawerCheckboxRef.current.checked = isOpen
+        }
+    }, [isOpen])
+
+    useEffect(() => {
+        if (!isOpen) {
+            return
+        }
+        if (isSelectableSharingOption(sharingStatus.sharingOption)) {
+            setSelectedOption(sharingStatus.sharingOption)
+        }
+    }, [isOpen, sharingStatus.sharingOption])
+
+    const currentOption = sharingStatus.sharingOption
+    const isLinkShared =
+        currentOption === "link-shared" ||
+        (selectedOption === "link-shared" && currentOption === "mixed")
+
+    const handleSharingChange = async (option: SelectableSharingOption) => {
+        setIsUpdating(true)
+        try {
+            const { isPublished, isShared } = flagsFromSharingOption(option)
+            await updateChampionshipSharingSettings(championshipId, isPublished, isShared)
+            setSelectedOption(option)
+            setError("Sharing settings updated for all championship days")
+
+            const refreshed = await getChampionshipSharingStatus(championshipId)
+            if (refreshed) {
+                onSharingUpdated(refreshed)
+            }
+        } catch (error) {
+            console.error("Failed to update championship sharing settings:", error)
+            setError(error instanceof Error ? error.message : "Failed to update sharing settings")
+        } finally {
+            setIsUpdating(false)
+        }
+    }
+
+    const handleCopyLink = async () => {
+        const resultsUrl = `${window.location.origin}/results/championships/${championshipId}`
+        try {
+            await navigator.clipboard.writeText(resultsUrl)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 2000)
+        } catch (error) {
+            console.error("Failed to copy link to clipboard:", error)
+            setError("Failed to copy link to clipboard")
+        }
+    }
+
+    const resultsUrl =
+        typeof window !== "undefined"
+            ? `${window.location.origin}/results/championships/${championshipId}`
+            : `/results/championships/${championshipId}`
+
+    const applyDisabled =
+        isUpdating ||
+        sharingStatus.tournamentCount === 0 ||
+        (currentOption !== "mixed" && selectedOption === currentOption)
+
+    return (
+        <div className="drawer drawer-end">
+            <input
+                ref={drawerCheckboxRef}
+                id={`championship-sharing-drawer-${championshipId}`}
+                type="checkbox"
+                className="drawer-toggle"
+                onChange={(event) => {
+                    if (!event.target.checked) {
+                        onClose()
+                    }
+                }}
+            />
+
+            <div className="drawer-side">
+                <label
+                    htmlFor={`championship-sharing-drawer-${championshipId}`}
+                    className="drawer-overlay"
+                    onClick={onClose}
+                />
+                <div className="min-h-full w-80 bg-base-200 p-4">
+                    <div className="flex items-center justify-between mb-4">
+                        <h3 className="text-lg font-semibold">Championship sharing</h3>
+                        <label
+                            htmlFor={`championship-sharing-drawer-${championshipId}`}
+                            className="btn btn-sm btn-circle btn-ghost"
+                            onClick={onClose}
+                        >
+                            ✕
+                        </label>
+                    </div>
+
+                    <p className="text-xs text-base-content/70 mb-4">
+                        Applies to all {sharingStatus.tournamentCount} day tournament
+                        {sharingStatus.tournamentCount === 1 ? "" : "s"} (standings and groups).
+                    </p>
+
+                    {currentOption === "mixed" ? (
+                        <div className="alert alert-warning text-xs mb-4 py-2">
+                            Day tournaments currently have different sharing settings. Choose an option to
+                            apply to all.
+                        </div>
+                    ) : null}
+
+                    {sharingStatus.tournamentCount === 0 ? (
+                        <div className="alert alert-info text-xs mb-4 py-2">
+                            Add at least one championship day before sharing results.
+                        </div>
+                    ) : null}
+
+                    <div className="space-y-4">
+                        <div className="form-control">
+                            <label className="label cursor-pointer">
+                                <div className="label-text">
+                                    <div className="font-semibold">Private</div>
+                                    <div className="text-xs text-base-content/70">
+                                        Results are not accessible to anyone
+                                    </div>
+                                </div>
+                                <input
+                                    type="radio"
+                                    name="championship-sharing-option"
+                                    className="radio radio-primary"
+                                    checked={selectedOption === "private"}
+                                    onChange={() => setSelectedOption("private")}
+                                    disabled={isUpdating || sharingStatus.tournamentCount === 0}
+                                />
+                            </label>
+                        </div>
+
+                        <div className="form-control">
+                            <label className="label cursor-pointer">
+                                <div className="label-text">
+                                    <div className="font-semibold">Link-Shared</div>
+                                    <div className="text-xs text-base-content/70">
+                                        Combined results accessible via direct link only
+                                    </div>
+                                </div>
+                                <input
+                                    type="radio"
+                                    name="championship-sharing-option"
+                                    className="radio radio-primary"
+                                    checked={selectedOption === "link-shared"}
+                                    onChange={() => setSelectedOption("link-shared")}
+                                    disabled={isUpdating || sharingStatus.tournamentCount === 0}
+                                />
+                            </label>
+                        </div>
+
+                        <div className="form-control">
+                            <label className="label cursor-pointer">
+                                <div className="label-text">
+                                    <div className="font-semibold">Public</div>
+                                    <div className="text-xs text-base-content/70">
+                                        Results visible on public results page
+                                    </div>
+                                </div>
+                                <input
+                                    type="radio"
+                                    name="championship-sharing-option"
+                                    className="radio radio-primary"
+                                    checked={selectedOption === "public"}
+                                    onChange={() => setSelectedOption("public")}
+                                    disabled={isUpdating || sharingStatus.tournamentCount === 0}
+                                />
+                            </label>
+                        </div>
+
+                        {isLinkShared && sharingStatus.tournamentCount > 0 ? (
+                            <div className="mt-6 space-y-2">
+                                <label className="label">
+                                    <span className="label-text font-semibold">Championship results link</span>
+                                </label>
+                                <div className="flex gap-2">
+                                    <input
+                                        type="text"
+                                        readOnly
+                                        value={resultsUrl}
+                                        className="input input-bordered flex-1 text-sm"
+                                    />
+                                    <button
+                                        type="button"
+                                        className="btn btn-primary"
+                                        onClick={handleCopyLink}
+                                        disabled={isUpdating}
+                                    >
+                                        {copied ? "Copied!" : "Copy"}
+                                    </button>
+                                </div>
+                            </div>
+                        ) : null}
+
+                        <div className="mt-6">
+                            <button
+                                type="button"
+                                className="btn btn-primary w-full"
+                                onClick={() => handleSharingChange(selectedOption)}
+                                disabled={applyDisabled}
+                            >
+                                {isUpdating ? "Updating..." : "Apply to all days"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export function championshipSharingBadgeLabel(option: SharingOption): string | null {
+    switch (option) {
+        case "public":
+            return "Public"
+        case "link-shared":
+            return "Link-shared"
+        case "mixed":
+            return "Mixed sharing"
+        default:
+            return null
+    }
+}

--- a/src/app/championships/__tests__/championshipActions.test.ts
+++ b/src/app/championships/__tests__/championshipActions.test.ts
@@ -6,6 +6,7 @@ import {
     createChampionship,
     enrollChampionshipCompetitorsOnDay,
     getChampionshipForOrganizer,
+    getChampionshipSharingStatus,
     listChampionshipDayEnrollmentByTournament,
     listChampionshipDayTournamentsForClubs,
     listChampionshipEnrolledMembershipNos,
@@ -17,6 +18,7 @@ import {
     unenrollChampionshipCompetitorFromDay,
     updateChampionship,
     updateChampionshipRegistration,
+    updateChampionshipSharingSettings,
 } from "../championshipActions"
 
 jest.mock("next/cache", () => ({
@@ -855,5 +857,75 @@ describe("listMyChampionshipsForClubs", () => {
 
         const call = prismaMock.championship.findMany.mock.calls[0][0]
         expect(call.where.isArchive).toBeUndefined()
+    })
+})
+
+describe("getChampionshipSharingStatus", () => {
+    it("returns null when championship is out of scope", async () => {
+        prismaMock.championship.findFirst.mockResolvedValue(null)
+
+        await expect(getChampionshipSharingStatus("champ-1")).resolves.toBeNull()
+    })
+
+    it("returns sharing status for linked tournaments", async () => {
+        prismaMock.championship.findFirst.mockResolvedValue({
+            id: "champ-1",
+            rounds: [
+                {
+                    tournamentId: "tour-1",
+                    tournament: { isPublished: false, isShared: true },
+                },
+                {
+                    tournamentId: "tour-2",
+                    tournament: { isPublished: false, isShared: true },
+                },
+            ],
+        } as never)
+
+        await expect(getChampionshipSharingStatus("champ-1")).resolves.toEqual({
+            tournamentCount: 2,
+            sharingOption: "link-shared",
+        })
+    })
+})
+
+describe("updateChampionshipSharingSettings", () => {
+    beforeEach(() => {
+        prismaMock.championship.findFirst.mockResolvedValue({
+            id: "champ-1",
+            isArchive: false,
+            rounds: [{ tournamentId: "tour-1" }, { tournamentId: "tour-2" }],
+        } as never)
+        prismaMock.tournament.updateMany.mockResolvedValue({ count: 2 } as never)
+    })
+
+    it("updates all linked tournaments", async () => {
+        await updateChampionshipSharingSettings("champ-1", false, true)
+
+        expect(prismaMock.tournament.updateMany).toHaveBeenCalledWith({
+            where: { id: { in: ["tour-1", "tour-2"] } },
+            data: { isPublished: false, isShared: true },
+        })
+    })
+
+    it("allows public sharing without score validation", async () => {
+        await updateChampionshipSharingSettings("champ-1", true, true)
+
+        expect(prismaMock.tournament.updateMany).toHaveBeenCalledWith({
+            where: { id: { in: ["tour-1", "tour-2"] } },
+            data: { isPublished: true, isShared: true },
+        })
+    })
+
+    it("throws when there are no day tournaments", async () => {
+        prismaMock.championship.findFirst.mockResolvedValue({
+            id: "champ-1",
+            isArchive: false,
+            rounds: [],
+        } as never)
+
+        await expect(updateChampionshipSharingSettings("champ-1", false, true)).rejects.toThrow(
+            "Add at least one championship day before sharing results"
+        )
     })
 })

--- a/src/app/championships/championshipActions.ts
+++ b/src/app/championships/championshipActions.ts
@@ -27,10 +27,14 @@ import {
 } from "@/lib/championshipRangeRules"
 import { assertChampionshipOrganizerClubs, resolveChampionshipOrganizerClubs } from "@/lib/championshipOrganizerSession"
 import {
-    calculateChampionshipCombinedStandings,
     type ChampionshipCombinedStandings,
 } from "@/lib/championshipCombinedStandings"
+import { buildChampionshipCombinedStandingsFromChampionshipData } from "@/lib/championshipStandingsInput"
 import { prismaOrThrow } from "@/lib/prisma"
+import {
+    aggregateSharingOption,
+    type SharingOption,
+} from "@/lib/tournamentSharing"
 
 export interface ChampionshipRangeFormatInput {
     rangeNumber: number
@@ -697,40 +701,16 @@ export async function getChampionshipCombinedStandings(
         return null
     }
 
-    const dayOrders = [...new Set(championship.rounds.map((round) => round.dayOrder))].sort(
-        (a, b) => a - b
-    )
-    const days = dayOrders.map((dayOrder) => ({
-        dayOrder,
-        tournamentId:
-            championship.rounds.find((round) => round.dayOrder === dayOrder)?.tournamentId ?? "",
-        label: `Day ${dayOrder}`,
-    }))
-    const rounds = championship.rounds.map((round) => ({
-        dayOrder: round.dayOrder,
-        rangeNumber: round.rangeNumber,
-        tournamentId: round.tournamentId,
-    }))
-
-    const registrations = championship.registrations.map((registration) => ({
-        membershipNo: registration.membershipNo,
-        competitorNumber: registration.competitorNumber,
-        name: registration.name,
-        club: registration.club,
-        ageGroupId: registration.ageGroupId,
-        categoryId: registration.categoryId,
-        genderGroup: registration.genderGroup,
-    }))
-
-    const enrollmentByMembership = buildEnrollmentByMembership(championship.rounds, enrollmentByTournament)
-
-    return calculateChampionshipCombinedStandings(
-        registrations,
-        days,
-        rounds,
+    return buildChampionshipCombinedStandingsFromChampionshipData({
+        registrations: championship.registrations,
+        rounds: championship.rounds.map((round) => ({
+            dayOrder: round.dayOrder,
+            rangeNumber: round.rangeNumber,
+            tournamentId: round.tournamentId,
+        })),
         scores,
-        enrollmentByMembership
-    )
+        enrollmentByTournament,
+    })
 }
 
 export type DivisionRangeMatrixRow = {
@@ -1548,4 +1528,76 @@ export async function archiveChampionship(championshipId: string) {
 
 export async function unarchiveChampionship(championshipId: string) {
     return setChampionshipArchiveState(championshipId, false)
+}
+
+export type ChampionshipSharingStatus = {
+    tournamentCount: number
+    sharingOption: SharingOption
+}
+
+async function listChampionshipTournamentIds(championshipId: string, clubs: string[]): Promise<string[]> {
+    const championship = await getChampionshipForOrganizer(championshipId, clubs)
+    if (!championship) {
+        throw new Error("Unauthorized")
+    }
+
+    return championship.rounds.map((round) => round.tournamentId)
+}
+
+export async function getChampionshipSharingStatus(
+    championshipId: string
+): Promise<ChampionshipSharingStatus | null> {
+    const clubs = await resolveChampionshipOrganizerClubs()
+    if (!clubs) {
+        return null
+    }
+    const championship = await getChampionshipForOrganizer(championshipId, clubs)
+    if (!championship) {
+        return null
+    }
+
+    const tournaments = championship.rounds.map((round) => ({
+        id: round.tournamentId,
+        isPublished: round.tournament.isPublished,
+        isShared: round.tournament.isShared,
+    }))
+
+    if (tournaments.length === 0) {
+        return {
+            tournamentCount: 0,
+            sharingOption: "private",
+        }
+    }
+
+    return {
+        tournamentCount: tournaments.length,
+        sharingOption: aggregateSharingOption(tournaments),
+    }
+}
+
+export async function updateChampionshipSharingSettings(
+    championshipId: string,
+    isPublished: boolean,
+    isShared: boolean
+): Promise<void> {
+    const clubs = await assertChampionshipOrganizerClubs()
+    await assertChampionshipWritable(championshipId)
+
+    const tournamentIds = await listChampionshipTournamentIds(championshipId, clubs)
+    if (tournamentIds.length === 0) {
+        throw new Error("Add at least one championship day before sharing results")
+    }
+
+    await prismaOrThrow("update championship sharing settings").tournament.updateMany({
+        where: { id: { in: tournamentIds } },
+        data: { isPublished, isShared },
+    })
+
+    revalidatePath(`/championships/${championshipId}`)
+    revalidatePath(`/results/championships/${championshipId}`)
+    revalidatePath("/results/championships")
+    revalidatePath("/results")
+    for (const tournamentId of tournamentIds) {
+        revalidatePath(`/tournaments/${tournamentId}/scores`)
+    }
 }

--- a/src/app/results/championships/[cId]/PublicChampionshipResultsTabs.tsx
+++ b/src/app/results/championships/[cId]/PublicChampionshipResultsTabs.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import ChampionshipCombinedStandingsView from "@/app/championships/[cId]/ChampionshipCombinedStandingsView"
+import type { ChampionshipCombinedStandings } from "@/lib/championshipCombinedStandings"
+import { useState } from "react"
+import type { PublicChampionshipTournamentRef, PublicTournamentGroupsData } from "../championshipResultsActions"
+
+const activeTabClass =
+    "tab-active bg-primary text-primary-content border-secondary border-solid border-1 border-b-0"
+
+const resultsPanelClass = "rounded-lg border border-base-300 bg-base-100 overflow-hidden"
+
+type ResultsTabId = number | "standings"
+
+function DayGroupCard({
+    heading,
+    groups,
+    unassigned,
+}: {
+    heading: string
+    groups: PublicTournamentGroupsData["groups"]
+    unassigned: PublicTournamentGroupsData["unassigned"]
+}) {
+    return (
+        <div className="card bg-base-100 border border-base-300">
+            <div className="card-body gap-4">
+                <h3 className="card-title text-base">{heading}</h3>
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                    {groups.map((group) => (
+                        <div key={group.groupNumber} className="rounded-lg border border-base-300 p-3">
+                            <div className="flex items-center justify-between mb-2">
+                                <p className="font-semibold">Group {group.groupNumber}</p>
+                                <p className="text-xs text-base-content/70">{group.participants.length}</p>
+                            </div>
+                            {group.participants.length === 0 ? (
+                                <p className="text-sm text-base-content/60">No assignments yet.</p>
+                            ) : (
+                                <ul className="space-y-1">
+                                    {group.participants.map((participant) => (
+                                        <li
+                                            key={participant.id}
+                                            className="flex items-baseline justify-between gap-3 text-sm"
+                                        >
+                                            <div className="min-w-0">
+                                                <p className="truncate font-medium">
+                                                    {participant.competitorNumber ? (
+                                                        <span className="font-mono text-xs mr-2">
+                                                            #{participant.competitorNumber}
+                                                        </span>
+                                                    ) : null}
+                                                    {participant.name}
+                                                    {participant.isCaptain ? (
+                                                        <span className="ml-2 badge badge-xs badge-outline">
+                                                            Captain
+                                                        </span>
+                                                    ) : null}
+                                                </p>
+                                                <p className="truncate text-xs text-base-content/70">
+                                                    {participant.club ?? "Independent"}
+                                                </p>
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+                {unassigned.length > 0 ? (
+                    <div className="rounded-lg bg-base-200 p-3">
+                        <p className="font-semibold mb-2">Unassigned ({unassigned.length})</p>
+                        <ul className="columns-1 md:columns-2 gap-6 space-y-1">
+                            {unassigned.map((participant) => (
+                                <li key={participant.id} className="text-sm break-inside-avoid">
+                                    <span className="font-mono text-xs mr-2">
+                                        {participant.competitorNumber ? `#${participant.competitorNumber}` : "—"}
+                                    </span>
+                                    <span className="font-medium">{participant.name}</span>
+                                    <span className="text-xs text-base-content/70">
+                                        {" "}
+                                        · {participant.club ?? "Independent"}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    )
+}
+
+function DayGroupAllocations({
+    dayOrder,
+    rounds,
+    groupsByTournamentId,
+}: {
+    dayOrder: number
+    rounds: PublicChampionshipTournamentRef[]
+    groupsByTournamentId: Record<string, PublicTournamentGroupsData>
+}) {
+    const dayRounds = rounds.filter((round) => round.dayOrder === dayOrder)
+
+    return (
+        <div className="space-y-3">
+            {dayRounds.map((round) => {
+                const groupsData = groupsByTournamentId[round.tournamentId]
+                if (!groupsData) {
+                    return null
+                }
+
+                return (
+                    <DayGroupCard
+                        key={round.tournamentId}
+                        heading={`Range ${round.rangeNumber} — ${round.tournamentName}`}
+                        groups={groupsData.groups}
+                        unassigned={groupsData.unassigned}
+                    />
+                )
+            })}
+        </div>
+    )
+}
+
+function StandingsPanel({ standings }: { standings: ChampionshipCombinedStandings | null }) {
+    if (standings) {
+        return <ChampionshipCombinedStandingsView standings={standings} embedded />
+    }
+
+    return <p className="text-sm text-base-content/70">Combined standings are not available yet.</p>
+}
+
+export default function PublicChampionshipResultsTabs({
+    dayOrders,
+    rounds,
+    groupsByTournamentId,
+    standings,
+}: {
+    dayOrders: number[]
+    rounds: PublicChampionshipTournamentRef[]
+    groupsByTournamentId: Record<string, PublicTournamentGroupsData>
+    standings: ChampionshipCombinedStandings | null
+}) {
+    const [activeTab, setActiveTab] = useState<ResultsTabId>(() => dayOrders[0] ?? "standings")
+
+    return (
+        <div className={resultsPanelClass}>
+            <div
+                role="tablist"
+                className="tabs tabs-boxed bg-base-200 w-full rounded-none border-b border-base-300"
+            >
+                {dayOrders.map((dayOrder) => (
+                    <button
+                        key={dayOrder}
+                        type="button"
+                        role="tab"
+                        aria-selected={activeTab === dayOrder}
+                        className={`tab flex-1 min-w-0 ${activeTab === dayOrder ? activeTabClass : "hover:bg-base-300"}`}
+                        onClick={() => setActiveTab(dayOrder)}
+                    >
+                        Day {dayOrder}
+                    </button>
+                ))}
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === "standings"}
+                    className={`tab flex-1 min-w-0 ${activeTab === "standings" ? activeTabClass : "hover:bg-base-300"}`}
+                    onClick={() => setActiveTab("standings")}
+                >
+                    Combined standings
+                </button>
+            </div>
+            <div className="p-4" role="tabpanel">
+                {activeTab === "standings" ? (
+                    <StandingsPanel standings={standings} />
+                ) : (
+                    <DayGroupAllocations
+                        dayOrder={activeTab}
+                        rounds={rounds}
+                        groupsByTournamentId={groupsByTournamentId}
+                    />
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/app/results/championships/[cId]/page.tsx
+++ b/src/app/results/championships/[cId]/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link"
+import { getPublicChampionshipResults } from "../championshipResultsActions"
+import PublicChampionshipResultsTabs from "./PublicChampionshipResultsTabs"
+
+export default async function PublicChampionshipResultsPage({ params }: { params: Promise<{ cId: string }> }) {
+    const { cId } = await params
+    const data = await getPublicChampionshipResults(cId)
+
+    const dayOrders = [...new Set(data.rounds.map((round) => round.dayOrder))].sort((a, b) => a - b)
+
+    return (
+        <div className="w-full p-6">
+            <div className="max-w-7xl mx-auto space-y-6">
+                <header className="space-y-1">
+                    <Link href="/results/championships" className="text-sm link link-hover">
+                        ← All championship results
+                    </Link>
+                    <h1 className="text-3xl font-bold">{data.championship.name}</h1>
+                    <p className="text-base-content/70">{data.championship.organizerClub}</p>
+                </header>
+
+                <PublicChampionshipResultsTabs
+                    dayOrders={dayOrders}
+                    rounds={data.rounds}
+                    groupsByTournamentId={data.groupsByTournamentId}
+                    standings={data.standings}
+                />
+            </div>
+        </div>
+    )
+}

--- a/src/app/results/championships/__tests__/championshipResultsActions.test.ts
+++ b/src/app/results/championships/__tests__/championshipResultsActions.test.ts
@@ -1,0 +1,53 @@
+import { prismaMock } from "@/test/prismaSingleton"
+import { listPublicChampionships } from "../championshipResultsActions"
+
+describe("listPublicChampionships", () => {
+    it("lists championships with at least one published day tournament", async () => {
+        prismaMock.championship.findMany.mockResolvedValue([
+            {
+                id: "champ-1",
+                name: "Spring Series",
+                organizerClub: "ClubA",
+                rounds: [
+                    {
+                        dayOrder: 1,
+                        tournament: { date: new Date("2026-05-01"), isPublished: true },
+                    },
+                    {
+                        dayOrder: 2,
+                        tournament: { date: new Date("2026-05-02"), isPublished: false },
+                    },
+                ],
+            },
+        ] as never)
+
+        await expect(listPublicChampionships()).resolves.toEqual([
+            {
+                id: "champ-1",
+                name: "Spring Series",
+                organizerClub: "ClubA",
+                dayCount: 1,
+                firstDate: new Date("2026-05-01"),
+                lastDate: new Date("2026-05-01"),
+            },
+        ])
+
+        expect(prismaMock.championship.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: {
+                    rounds: {
+                        some: {
+                            tournament: { isPublished: true },
+                        },
+                    },
+                },
+            })
+        )
+    })
+
+    it("propagates database errors", async () => {
+        prismaMock.championship.findMany.mockRejectedValue(new Error("db unavailable"))
+
+        await expect(listPublicChampionships()).rejects.toThrow("db unavailable")
+    })
+})

--- a/src/app/results/championships/championshipResultsActions.ts
+++ b/src/app/results/championships/championshipResultsActions.ts
@@ -1,0 +1,293 @@
+"use server"
+
+import { prismaOrThrow } from "@/lib/prisma"
+import { notFound } from "next/navigation"
+import { buildChampionshipCombinedStandingsFromChampionshipData } from "@/lib/championshipStandingsInput"
+import type { ChampionshipCombinedStandings } from "@/lib/championshipCombinedStandings"
+
+export type PublicChampionshipTournamentRef = {
+    dayOrder: number
+    rangeNumber: number
+    tournamentId: string
+    tournamentName: string
+    date: Date
+    organizerClub: string
+    endCount: number
+    groupSize: number
+    isPublished: boolean
+    isShared: boolean
+}
+
+export type PublicTournamentGroup = {
+    groupNumber: number
+    participants: {
+        id: string
+        membershipNo: string
+        competitorNumber: number | null
+        name: string
+        club: string | null
+        isCaptain: boolean
+    }[]
+}
+
+export type PublicTournamentGroupsData = {
+    tournament: Pick<PublicChampionshipTournamentRef, "tournamentId" | "tournamentName" | "endCount" | "groupSize">
+    groups: PublicTournamentGroup[]
+    unassigned: {
+        id: string
+        membershipNo: string
+        competitorNumber: number | null
+        name: string
+        club: string | null
+    }[]
+}
+
+export type PublicChampionshipResultsData = {
+    championship: { id: string; name: string; organizerClub: string }
+    rounds: PublicChampionshipTournamentRef[]
+    standings: ChampionshipCombinedStandings | null
+    groupsByTournamentId: Record<string, PublicTournamentGroupsData>
+}
+
+export type PublicChampionshipListItem = {
+    id: string
+    name: string
+    organizerClub: string
+    dayCount: number
+    firstDate: Date | null
+    lastDate: Date | null
+}
+
+function isTournamentPublic(t: { isPublished: boolean; isShared: boolean }): boolean {
+    return t.isPublished || t.isShared
+}
+
+function groupsFromParticipants(
+    endCount: number,
+    participants: {
+        id: string
+        membershipNo: string
+        competitorNumber: number | null
+        name: string
+        club: string | null
+        groupAssignment: { groupNumber: number; isCaptain: boolean } | null
+    }[]
+): { groups: PublicTournamentGroup[]; unassigned: PublicTournamentGroupsData["unassigned"] } {
+    const groups: PublicTournamentGroup[] = Array.from({ length: endCount }, (_, index) => ({
+        groupNumber: index + 1,
+        participants: [],
+    }))
+
+    const unassigned: PublicTournamentGroupsData["unassigned"] = []
+
+    for (const participant of participants) {
+        const assignment = participant.groupAssignment
+        if (!assignment) {
+            unassigned.push({
+                id: participant.id,
+                membershipNo: participant.membershipNo,
+                competitorNumber: participant.competitorNumber,
+                name: participant.name,
+                club: participant.club,
+            })
+            continue
+        }
+
+        const group = groups[assignment.groupNumber - 1]
+        if (!group) {
+            continue
+        }
+        group.participants.push({
+            id: participant.id,
+            membershipNo: participant.membershipNo,
+            competitorNumber: participant.competitorNumber,
+            name: participant.name,
+            club: participant.club,
+            isCaptain: assignment.isCaptain,
+        })
+    }
+
+    for (const group of groups) {
+        group.participants.sort((a, b) => {
+            if (a.isCaptain !== b.isCaptain) {
+                return a.isCaptain ? -1 : 1
+            }
+            return a.name.localeCompare(b.name)
+        })
+    }
+
+    unassigned.sort((a, b) => a.name.localeCompare(b.name))
+    return { groups, unassigned }
+}
+
+function toPublicChampionshipListItem(championship: {
+    id: string
+    name: string
+    organizerClub: string
+    rounds: { dayOrder: number; tournament: { date: Date; isPublished: boolean } }[]
+}): PublicChampionshipListItem {
+    const publishedRounds = championship.rounds.filter((round) => round.tournament.isPublished)
+    const dayOrders = new Set(publishedRounds.map((round) => round.dayOrder))
+    const dates = publishedRounds.map((round) => round.tournament.date.getTime())
+
+    return {
+        id: championship.id,
+        name: championship.name,
+        organizerClub: championship.organizerClub,
+        dayCount: dayOrders.size,
+        firstDate: dates.length > 0 ? new Date(Math.min(...dates)) : null,
+        lastDate: dates.length > 0 ? new Date(Math.max(...dates)) : null,
+    }
+}
+
+export async function listPublicChampionships(): Promise<PublicChampionshipListItem[]> {
+    const championships = await prismaOrThrow("list public championships").championship.findMany({
+        where: {
+            rounds: {
+                some: {
+                    tournament: { isPublished: true },
+                },
+            },
+        },
+        include: {
+            rounds: {
+                include: {
+                    tournament: {
+                        select: { date: true, isPublished: true },
+                    },
+                },
+            },
+        },
+        orderBy: { name: "asc" },
+    })
+
+    return championships
+        .map(toPublicChampionshipListItem)
+        .sort((a, b) => (b.lastDate?.getTime() ?? 0) - (a.lastDate?.getTime() ?? 0))
+}
+
+export async function getPublicChampionshipResults(championshipId: string): Promise<PublicChampionshipResultsData> {
+    const championship = await prismaOrThrow("get public championship").championship.findUnique({
+        where: { id: championshipId },
+        include: {
+            registrations: {
+                include: {
+                    ageGroup: true,
+                    category: true,
+                },
+            },
+            rounds: {
+                include: {
+                    tournament: true,
+                },
+            },
+        },
+    })
+
+    if (!championship) {
+        notFound()
+    }
+
+    const publicRounds = championship.rounds
+        .filter((round) => isTournamentPublic(round.tournament))
+        .map((round) => ({
+            dayOrder: round.dayOrder,
+            rangeNumber: round.rangeNumber,
+            tournamentId: round.tournamentId,
+            tournamentName: round.tournament.name,
+            date: round.tournament.date,
+            organizerClub: round.tournament.organizerClub,
+            endCount: round.tournament.endCount,
+            groupSize: round.tournament.groupSize,
+            isPublished: round.tournament.isPublished,
+            isShared: round.tournament.isShared,
+        }))
+        .sort((a, b) => (a.dayOrder - b.dayOrder) || (a.rangeNumber - b.rangeNumber))
+
+    if (publicRounds.length === 0) {
+        notFound()
+    }
+
+    const tournamentIds = publicRounds.map((round) => round.tournamentId)
+
+    const [enrollmentRows, scoreRows, groupParticipants] = await Promise.all([
+        prismaOrThrow("get public championship enrollment").participant.findMany({
+            where: { tournamentId: { in: tournamentIds } },
+            select: { tournamentId: true, membershipNo: true },
+        }),
+        prismaOrThrow("get public championship scores").participant.findMany({
+            where: { tournamentId: { in: tournamentIds } },
+            select: {
+                tournamentId: true,
+                membershipNo: true,
+                participantScore: { select: { score: true } },
+            },
+        }),
+        prismaOrThrow("get public championship groups").participant.findMany({
+            where: { tournamentId: { in: tournamentIds } },
+            select: {
+                id: true,
+                tournamentId: true,
+                membershipNo: true,
+                competitorNumber: true,
+                name: true,
+                club: true,
+                groupAssignment: { select: { groupNumber: true, isCaptain: true } },
+            },
+        }),
+    ])
+
+    const enrollmentByTournament: Record<string, string[]> = {}
+    for (const row of enrollmentRows) {
+        enrollmentByTournament[row.tournamentId] ??= []
+        enrollmentByTournament[row.tournamentId].push(row.membershipNo)
+    }
+
+    const scores = scoreRows.map((row) => ({
+        tournamentId: row.tournamentId,
+        membershipNo: row.membershipNo,
+        rawScore: row.participantScore ? Number(row.participantScore.score) : null,
+    }))
+
+    const standings = buildChampionshipCombinedStandingsFromChampionshipData({
+        registrations: championship.registrations,
+        rounds: publicRounds.map((round) => ({
+            dayOrder: round.dayOrder,
+            rangeNumber: round.rangeNumber,
+            tournamentId: round.tournamentId,
+        })),
+        scores,
+        enrollmentByTournament,
+    })
+
+    const participantsByTournament = new Map<string, typeof groupParticipants>()
+    for (const participant of groupParticipants) {
+        const existing = participantsByTournament.get(participant.tournamentId) ?? []
+        existing.push(participant)
+        participantsByTournament.set(participant.tournamentId, existing)
+    }
+
+    const groupsByTournamentId: Record<string, PublicTournamentGroupsData> = {}
+    for (const round of publicRounds) {
+        const participants = participantsByTournament.get(round.tournamentId) ?? []
+        const { groups, unassigned } = groupsFromParticipants(round.endCount, participants)
+        groupsByTournamentId[round.tournamentId] = {
+            tournament: {
+                tournamentId: round.tournamentId,
+                tournamentName: round.tournamentName,
+                endCount: round.endCount,
+                groupSize: round.groupSize,
+            },
+            groups,
+            unassigned,
+        }
+    }
+
+    return {
+        championship: { id: championship.id, name: championship.name, organizerClub: championship.organizerClub },
+        rounds: publicRounds,
+        standings,
+        groupsByTournamentId,
+    }
+}
+

--- a/src/app/results/championships/page.tsx
+++ b/src/app/results/championships/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link"
+import { listPublicChampionships } from "./championshipResultsActions"
+
+function formatDateRange(firstDate: Date | null, lastDate: Date | null): string {
+    if (!firstDate || !lastDate) {
+        return "Dates TBD"
+    }
+
+    const formatter = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" })
+    if (firstDate.getTime() === lastDate.getTime()) {
+        return formatter.format(firstDate)
+    }
+
+    return `${formatter.format(firstDate)} – ${formatter.format(lastDate)}`
+}
+
+export default async function PublicChampionshipResultsIndexPage() {
+    const championships = await listPublicChampionships()
+
+    return (
+        <div className="w-full p-6">
+            <div className="max-w-4xl mx-auto">
+                <h1 className="text-3xl font-bold mb-2">Championship Results</h1>
+                <p className="text-base-content/70 mb-6">
+                    Multi-day championships with published combined standings and group allocations.
+                </p>
+
+                {championships.length === 0 ? (
+                    <div className="text-center py-12">
+                        <p className="text-lg text-base-content/70">No published championship results available</p>
+                        <p className="text-sm text-base-content/50 mt-2">Check back later for championship results</p>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {championships.map((championship) => (
+                            <div key={championship.id} className="card bg-base-100 shadow-md">
+                                <div className="card-body">
+                                    <div className="flex flex-wrap items-center justify-between gap-4">
+                                        <div>
+                                            <h2 className="card-title">{championship.name}</h2>
+                                            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-base-content/70">
+                                                <span>{championship.organizerClub}</span>
+                                                <span>
+                                                    {championship.dayCount} day{championship.dayCount === 1 ? "" : "s"}
+                                                </span>
+                                                <span>{formatDateRange(championship.firstDate, championship.lastDate)}</span>
+                                            </div>
+                                        </div>
+                                        <Link
+                                            href={`/results/championships/${championship.id}`}
+                                            className="btn btn-primary"
+                                        >
+                                            View results
+                                        </Link>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/app/tournaments/[tId]/scoreActions.ts
+++ b/src/app/tournaments/[tId]/scoreActions.ts
@@ -2,6 +2,10 @@
 
 import { GroupAssignment, Participant } from "@/generated/prisma/client"
 import { prismaOrThrow } from "@/lib/prisma"
+import {
+    isTournamentResultsComplete,
+    validateCheckedInParticipantsHaveScores,
+} from "@/lib/tournamentSharingValidation"
 import { ParticipantResult, SCORE_DNC, SCORE_DNF, toResult, toScore } from "@/lib/scoreUtils"
 import { revalidatePath } from "next/cache"
 
@@ -54,7 +58,8 @@ export async function getTournamentWithResultsStatus(tournamentId: string): Prom
         throw new Error("Tournament not found")
     }
 
-    const allResultsComplete = tournament.participants.length > 0 && tournament.participants.every(p => !!p.participantScore)
+    const allResultsComplete =
+        tournament.participants.length > 0 && tournament.participants.every((p) => !!p.participantScore)
 
     return {
         tournament: {
@@ -121,37 +126,6 @@ export async function updateShootoffScore(
     })
 
     revalidatePath(`/tournaments/${tournamentId}/scores`)
-}
-
-async function validateCheckedInParticipantsHaveScores(
-    tournamentId: string,
-    errorMessagePrefix: string
-): Promise<void> {
-    const tournament = await prismaOrThrow("validate checked-in participants have scores").tournament.findUnique({
-        where: { id: tournamentId },
-        include: {
-            participants: {
-                where: {
-                    checkedIn: true
-                },
-                include: {
-                    participantScore: true
-                }
-            }
-        }
-    })
-
-    if (!tournament) {
-        throw new Error("Tournament not found")
-    }
-
-    const incompleteParticipants = tournament.participants.filter(p =>
-        !p.participantScore
-    )
-
-    if (incompleteParticipants.length > 0) {
-        throw new Error(`${errorMessagePrefix}: ${incompleteParticipants.length} participants have incomplete scores`)
-    }
 }
 
 export async function updateSharingSettings(

--- a/src/app/tournaments/[tId]/scores/SharingDrawer.tsx
+++ b/src/app/tournaments/[tId]/scores/SharingDrawer.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import useErrorContext from "@/components/errors/ErrorContext"
+import { sharingOptionFromFlags } from "@/lib/tournamentSharing"
 import { useEffect, useMemo, useRef, useState } from "react"
 import useTournamentContext from "../TournamentContext"
 import { updateSharingSettings } from "../scoreActions"
@@ -19,12 +20,10 @@ interface SharingDrawerProps {
     onSharingUpdated?: (updatedTournament: TournamentData) => void
 }
 
-type SharingOption = 'private' | 'link-shared' | 'public'
+type TournamentSharingOption = Exclude<import("@/lib/tournamentSharing").SharingOption, "mixed">
 
-function sharingOptionFromTournament(t: { isPublished: boolean; isShared: boolean }): SharingOption {
-    if (t.isPublished && t.isShared) return 'public'
-    if (!t.isPublished && t.isShared) return 'link-shared'
-    return 'private'
+function sharingOptionFromTournament(t: { isPublished: boolean; isShared: boolean }): TournamentSharingOption {
+    return sharingOptionFromFlags(t.isPublished, t.isShared) as TournamentSharingOption
 }
 
 export default function SharingDrawer({ isOpen, onClose, allResultsComplete, tournament: tournamentProp, onSharingUpdated }: SharingDrawerProps) {
@@ -33,7 +32,7 @@ export default function SharingDrawer({ isOpen, onClose, allResultsComplete, tou
     const [isUpdating, setIsUpdating] = useState(false)
     const [copied, setCopied] = useState(false)
     const drawerCheckboxRef = useRef<HTMLInputElement>(null)
-    const [selectedOption, setSelectedOption] = useState<SharingOption>('private')
+    const [selectedOption, setSelectedOption] = useState<TournamentSharingOption>("private")
 
     const tFromContext = tCtx?.getTournament()
     const tournamentResolved = useMemo((): TournamentData | null => {
@@ -73,9 +72,9 @@ export default function SharingDrawer({ isOpen, onClose, allResultsComplete, tou
 
     const tournament = tournamentResolved
 
-    const getCurrentSharingOption = (): SharingOption => sharingOptionFromTournament(tournament)
+    const getCurrentSharingOption = (): TournamentSharingOption => sharingOptionFromTournament(tournament)
 
-    const handleSharingChange = async (option: SharingOption) => {
+    const handleSharingChange = async (option: TournamentSharingOption) => {
         if (option === 'public' && !allResultsComplete) {
             setError("Cannot make results public: all participants must have completed scores")
             return

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -20,6 +20,7 @@ export default async function Navigation({ className }: { className?: string }) 
                     </div>
                     <ul tabIndex={0} className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
                         <li><Link href="/results">Results</Link></li>
+                        <li><Link href="/results/championships">Championship Results</Link></li>
                         {authenticated && (
                             <>
                                 <li><Link href="/tournaments">My Tournaments</Link></li>
@@ -35,6 +36,7 @@ export default async function Navigation({ className }: { className?: string }) 
             <div className="navbar-center hidden lg:flex">
                 <ul className="menu menu-horizontal px-1 bg-primary rounded-box">
                     <li><Link href="/results">Results</Link></li>
+                    <li><Link href="/results/championships">Championship Results</Link></li>
                     {authenticated && (
                         <>
                             <li><Link href="/tournaments">My Tournaments</Link></li>

--- a/src/lib/__tests__/championshipCombinedStandings.test.ts
+++ b/src/lib/__tests__/championshipCombinedStandings.test.ts
@@ -1,6 +1,7 @@
 import {
     calculateChampionshipCombinedStandings,
     championshipCategoryKey,
+    compareCombinedStandingsCategories,
 } from "@/lib/championshipCombinedStandings"
 import { SCORE_DNC, toScore } from "@/lib/scoreUtils"
 
@@ -22,7 +23,9 @@ describe("championshipCombinedStandings", () => {
             name: "Alex",
             club: "Club A",
             ageGroupId: "age-1",
+            ageGroupName: "Adult",
             categoryId: "cat-1",
+            categoryName: "Barebow Compound",
             genderGroup: "M",
         },
         {
@@ -31,7 +34,9 @@ describe("championshipCombinedStandings", () => {
             name: "Blair",
             club: "Club B",
             ageGroupId: "age-1",
+            ageGroupName: "Adult",
             categoryId: "cat-1",
+            categoryName: "Barebow Compound",
             genderGroup: "M",
         },
     ]
@@ -149,5 +154,84 @@ describe("championshipCombinedStandings", () => {
 
         expect(standings?.complete[0]?.competitors[0]?.place).toBe(1)
         expect(standings?.inProgress).toHaveLength(0)
+    })
+
+    it("sorts category groups by bow, age, then gender", () => {
+        const mixedRegistrations = [
+            {
+                membershipNo: "M-001",
+                competitorNumber: 1,
+                name: "Alex",
+                club: "Club A",
+                ageGroupId: "A",
+                ageGroupName: "Adult",
+                categoryId: "FSR",
+                categoryName: "Freestyle Recurve",
+                genderGroup: "M",
+            },
+            {
+                membershipNo: "M-002",
+                competitorNumber: 2,
+                name: "Blair",
+                club: "Club B",
+                ageGroupId: "C",
+                ageGroupName: "Cub",
+                categoryId: "BBC",
+                categoryName: "Barebow Compound",
+                genderGroup: "M",
+            },
+            {
+                membershipNo: "M-003",
+                competitorNumber: 3,
+                name: "Casey",
+                club: "Club C",
+                ageGroupId: "C",
+                ageGroupName: "Cub",
+                categoryId: "BBC",
+                categoryName: "Barebow Compound",
+                genderGroup: "F",
+            },
+            {
+                membershipNo: "M-004",
+                competitorNumber: 4,
+                name: "Dana",
+                club: "Club D",
+                ageGroupId: "J",
+                ageGroupName: "Junior",
+                categoryId: "BBC",
+                categoryName: "Barebow Compound",
+                genderGroup: "M",
+            },
+        ]
+
+        const standings = calculateChampionshipCombinedStandings(
+            mixedRegistrations,
+            days,
+            rounds,
+            [],
+            Object.fromEntries(mixedRegistrations.map((registration) => [registration.membershipNo, []]))
+        )
+
+        expect(standings?.inProgress.map((group) => group.categoryKey)).toEqual([
+            championshipCategoryKey("C", "F", "BBC"),
+            championshipCategoryKey("C", "M", "BBC"),
+            championshipCategoryKey("J", "M", "BBC"),
+            championshipCategoryKey("A", "M", "FSR"),
+        ])
+    })
+
+    it("compareCombinedStandingsCategories uses bow, age, then gender", () => {
+        expect(
+            compareCombinedStandingsCategories(
+                { categoryName: "Barebow Compound", ageGroupName: "Cub", genderGroup: "M" },
+                { categoryName: "Freestyle Recurve", ageGroupName: "Adult", genderGroup: "M" }
+            )
+        ).toBeLessThan(0)
+        expect(
+            compareCombinedStandingsCategories(
+                { categoryName: "Barebow Compound", ageGroupName: "Cub", genderGroup: "F" },
+                { categoryName: "Barebow Compound", ageGroupName: "Cub", genderGroup: "M" }
+            )
+        ).toBeLessThan(0)
     })
 })

--- a/src/lib/__tests__/championshipStandingsInput.test.ts
+++ b/src/lib/__tests__/championshipStandingsInput.test.ts
@@ -1,0 +1,88 @@
+import {
+    buildChampionshipCombinedStandingsFromChampionshipData,
+    buildChampionshipStandingsDays,
+    mapChampionshipRegistrationsToStandings,
+} from "../championshipStandingsInput"
+
+describe("mapChampionshipRegistrationsToStandings", () => {
+    it("maps registration profile fields for standings calculation", () => {
+        expect(
+            mapChampionshipRegistrationsToStandings([
+                {
+                    membershipNo: "M-001",
+                    competitorNumber: 1,
+                    name: "Alex",
+                    club: "Club A",
+                    ageGroupId: "A",
+                    genderGroup: "M",
+                    categoryId: "BBC",
+                    ageGroup: { name: "Adult" },
+                    category: { name: "Barebow Compound" },
+                },
+            ])
+        ).toEqual([
+            {
+                membershipNo: "M-001",
+                competitorNumber: 1,
+                name: "Alex",
+                club: "Club A",
+                ageGroupId: "A",
+                ageGroupName: "Adult",
+                categoryId: "BBC",
+                categoryName: "Barebow Compound",
+                genderGroup: "M",
+            },
+        ])
+    })
+})
+
+describe("buildChampionshipStandingsDays", () => {
+    it("builds ordered day labels from round tournaments", () => {
+        expect(
+            buildChampionshipStandingsDays([
+                { dayOrder: 2, rangeNumber: 1, tournamentId: "t2" },
+                { dayOrder: 1, rangeNumber: 1, tournamentId: "t1" },
+                { dayOrder: 1, rangeNumber: 2, tournamentId: "t1b" },
+            ])
+        ).toEqual([
+            { dayOrder: 1, tournamentId: "t1", label: "Day 1" },
+            { dayOrder: 2, tournamentId: "t2", label: "Day 2" },
+        ])
+    })
+})
+
+describe("buildChampionshipCombinedStandingsFromChampionshipData", () => {
+    it("returns null when there are no championship days", () => {
+        expect(
+            buildChampionshipCombinedStandingsFromChampionshipData({
+                registrations: [],
+                rounds: [],
+                scores: [],
+                enrollmentByTournament: {},
+            })
+        ).toBeNull()
+    })
+
+    it("calculates standings from shared championship inputs", () => {
+        const standings = buildChampionshipCombinedStandingsFromChampionshipData({
+            registrations: [
+                {
+                    membershipNo: "M-001",
+                    competitorNumber: 1,
+                    name: "Alex",
+                    club: "Club A",
+                    ageGroupId: "A",
+                    genderGroup: "M",
+                    categoryId: "BBC",
+                    ageGroup: { name: "Adult" },
+                    category: { name: "Barebow Compound" },
+                },
+            ],
+            rounds: [{ dayOrder: 1, rangeNumber: 1, tournamentId: "t1" }],
+            scores: [{ tournamentId: "t1", membershipNo: "M-001", rawScore: 290 }],
+            enrollmentByTournament: { t1: ["M-001"] },
+        })
+
+        expect(standings?.complete[0]?.competitors[0]?.totalLabel).toBe("290")
+    })
+})

--- a/src/lib/__tests__/tournamentSharing.test.ts
+++ b/src/lib/__tests__/tournamentSharing.test.ts
@@ -1,0 +1,45 @@
+import {
+    aggregateSharingOption,
+    flagsFromSharingOption,
+    sharingOptionFromFlags,
+} from "../tournamentSharing"
+
+describe("sharingOptionFromFlags", () => {
+    it("maps private, link-shared, and public flags", () => {
+        expect(sharingOptionFromFlags(false, false)).toBe("private")
+        expect(sharingOptionFromFlags(false, true)).toBe("link-shared")
+        expect(sharingOptionFromFlags(true, true)).toBe("public")
+    })
+})
+
+describe("flagsFromSharingOption", () => {
+    it("maps options back to flags", () => {
+        expect(flagsFromSharingOption("private")).toEqual({ isPublished: false, isShared: false })
+        expect(flagsFromSharingOption("link-shared")).toEqual({ isPublished: false, isShared: true })
+        expect(flagsFromSharingOption("public")).toEqual({ isPublished: true, isShared: true })
+    })
+})
+
+describe("aggregateSharingOption", () => {
+    it("returns private when there are no tournaments", () => {
+        expect(aggregateSharingOption([])).toBe("private")
+    })
+
+    it("returns the shared option when all tournaments match", () => {
+        expect(
+            aggregateSharingOption([
+                { isPublished: false, isShared: true },
+                { isPublished: false, isShared: true },
+            ])
+        ).toBe("link-shared")
+    })
+
+    it("returns mixed when tournaments differ", () => {
+        expect(
+            aggregateSharingOption([
+                { isPublished: false, isShared: false },
+                { isPublished: false, isShared: true },
+            ])
+        ).toBe("mixed")
+    })
+})

--- a/src/lib/championshipCombinedStandings.ts
+++ b/src/lib/championshipCombinedStandings.ts
@@ -24,7 +24,9 @@ export type RegisteredCompetitor = {
     name: string
     club: string
     ageGroupId: string
+    ageGroupName: string
     categoryId: string
+    categoryName: string
     genderGroup: string
 }
 
@@ -47,6 +49,8 @@ type CompetitorStanding = {
     ageGroupId: string
     categoryId: string
     genderGroup: string
+    categoryName: string
+    ageGroupName: string
     categoryKey: string
     categoryLabel: string
     scoresByDay: Record<number, DayScoreStatus>
@@ -57,6 +61,9 @@ type CompetitorStanding = {
 type CategoryStandings = {
     categoryKey: string
     categoryLabel: string
+    categoryName: string
+    ageGroupName: string
+    genderGroup: string
     scoringComplete: boolean
     competitors: CompetitorStanding[]
 }
@@ -91,6 +98,27 @@ export function championshipCategoryKey(
     categoryId: string
 ): string {
     return `${ageGroupId}${genderGroup}${categoryId}`
+}
+
+function compareAlphanumeric(a: string, b: string): number {
+    return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" })
+}
+
+export function compareCombinedStandingsCategories(
+    a: { categoryName: string; ageGroupName: string; genderGroup: string },
+    b: { categoryName: string; ageGroupName: string; genderGroup: string }
+): number {
+    const byBow = compareAlphanumeric(a.categoryName, b.categoryName)
+    if (byBow !== 0) {
+        return byBow
+    }
+
+    const byAge = compareAlphanumeric(a.ageGroupName, b.ageGroupName)
+    if (byAge !== 0) {
+        return byAge
+    }
+
+    return compareAlphanumeric(a.genderGroup, b.genderGroup)
 }
 
 function formatStandingsTotal(total: number | null): string {
@@ -202,6 +230,8 @@ function calculateCompetitorStandings(
             ageGroupId: registration.ageGroupId,
             categoryId: registration.categoryId,
             genderGroup: registration.genderGroup,
+            categoryName: registration.categoryName,
+            ageGroupName: registration.ageGroupName,
             categoryKey: championshipCategoryKey(
                 registration.ageGroupId,
                 registration.genderGroup,
@@ -244,11 +274,14 @@ function groupStandingsByCategory(competitors: CompetitorStanding[]): CategorySt
             return {
                 categoryKey,
                 categoryLabel: sortedCompetitors[0]?.categoryLabel ?? categoryKey,
+                categoryName: sortedCompetitors[0]?.categoryName ?? "",
+                ageGroupName: sortedCompetitors[0]?.ageGroupName ?? "",
+                genderGroup: sortedCompetitors[0]?.genderGroup ?? "",
                 scoringComplete: sortedCompetitors.every((competitor) => competitor.scoringComplete),
                 competitors: sortedCompetitors,
             }
         })
-        .sort((a, b) => a.categoryLabel.localeCompare(b.categoryLabel))
+        .sort(compareCombinedStandingsCategories)
 }
 
 function formatDayScoreLabel(dayScore: DayScoreStatus | undefined): string {

--- a/src/lib/championshipStandingsInput.ts
+++ b/src/lib/championshipStandingsInput.ts
@@ -1,0 +1,78 @@
+import { buildEnrollmentByMembership } from "@/lib/championshipEnrollment"
+import {
+    calculateChampionshipCombinedStandings,
+    type ChampionshipCombinedStandings,
+    type ChampionshipDay,
+    type ChampionshipRoundRef,
+    type DayScoreInput,
+    type RegisteredCompetitor,
+} from "@/lib/championshipCombinedStandings"
+
+export type ChampionshipStandingsRegistrationSource = {
+    membershipNo: string
+    competitorNumber: number
+    name: string
+    club: string
+    ageGroupId: string
+    genderGroup: string
+    categoryId: string
+    ageGroup: { name: string }
+    category: { name: string }
+}
+
+export type ChampionshipStandingsRoundSource = ChampionshipRoundRef
+
+export function mapChampionshipRegistrationsToStandings(
+    registrations: ChampionshipStandingsRegistrationSource[]
+): RegisteredCompetitor[] {
+    return registrations.map((registration) => ({
+        membershipNo: registration.membershipNo,
+        competitorNumber: registration.competitorNumber,
+        name: registration.name,
+        club: registration.club,
+        ageGroupId: registration.ageGroupId,
+        ageGroupName: registration.ageGroup.name,
+        categoryId: registration.categoryId,
+        categoryName: registration.category.name,
+        genderGroup: registration.genderGroup,
+    }))
+}
+
+export function buildChampionshipStandingsDays(
+    rounds: Pick<ChampionshipRoundRef, "dayOrder" | "tournamentId">[]
+): ChampionshipDay[] {
+    const dayOrders = [...new Set(rounds.map((round) => round.dayOrder))].sort((a, b) => a - b)
+
+    return dayOrders.map((dayOrder) => ({
+        dayOrder,
+        tournamentId: rounds.find((round) => round.dayOrder === dayOrder)?.tournamentId ?? "",
+        label: `Day ${dayOrder}`,
+    }))
+}
+
+export function buildChampionshipCombinedStandingsFromChampionshipData({
+    registrations,
+    rounds,
+    scores,
+    enrollmentByTournament,
+}: {
+    registrations: ChampionshipStandingsRegistrationSource[]
+    rounds: ChampionshipStandingsRoundSource[]
+    scores: DayScoreInput[]
+    enrollmentByTournament: Record<string, string[]>
+}): ChampionshipCombinedStandings | null {
+    const days = buildChampionshipStandingsDays(rounds)
+    if (days.length === 0) {
+        return null
+    }
+
+    const enrollmentByMembership = buildEnrollmentByMembership(rounds, enrollmentByTournament)
+
+    return calculateChampionshipCombinedStandings(
+        mapChampionshipRegistrationsToStandings(registrations),
+        days,
+        rounds,
+        scores,
+        enrollmentByMembership
+    )
+}

--- a/src/lib/tournamentSharing.ts
+++ b/src/lib/tournamentSharing.ts
@@ -1,0 +1,39 @@
+export type SharingOption = "private" | "link-shared" | "public" | "mixed"
+
+export function sharingOptionFromFlags(isPublished: boolean, isShared: boolean): SharingOption {
+    if (isPublished && isShared) {
+        return "public"
+    }
+    if (!isPublished && isShared) {
+        return "link-shared"
+    }
+    return "private"
+}
+
+export function flagsFromSharingOption(option: Exclude<SharingOption, "mixed">): {
+    isPublished: boolean
+    isShared: boolean
+} {
+    switch (option) {
+        case "private":
+            return { isPublished: false, isShared: false }
+        case "link-shared":
+            return { isPublished: false, isShared: true }
+        case "public":
+            return { isPublished: true, isShared: true }
+    }
+}
+
+export function aggregateSharingOption(
+    tournaments: { isPublished: boolean; isShared: boolean }[]
+): SharingOption {
+    if (tournaments.length === 0) {
+        return "private"
+    }
+
+    const first = sharingOptionFromFlags(tournaments[0].isPublished, tournaments[0].isShared)
+    const allSame = tournaments.every(
+        (tournament) => sharingOptionFromFlags(tournament.isPublished, tournament.isShared) === first
+    )
+    return allSame ? first : "mixed"
+}

--- a/src/lib/tournamentSharingValidation.ts
+++ b/src/lib/tournamentSharingValidation.ts
@@ -1,0 +1,46 @@
+import { prismaOrThrow } from "@/lib/prisma"
+
+export async function validateCheckedInParticipantsHaveScores(
+    tournamentId: string,
+    errorMessagePrefix: string
+): Promise<void> {
+    const tournament = await prismaOrThrow("validate checked-in participants have scores").tournament.findUnique({
+        where: { id: tournamentId },
+        include: {
+            participants: {
+                where: { checkedIn: true },
+                include: { participantScore: true },
+            },
+        },
+    })
+
+    if (!tournament) {
+        throw new Error("Tournament not found")
+    }
+
+    const incompleteParticipants = tournament.participants.filter((participant) => !participant.participantScore)
+
+    if (incompleteParticipants.length > 0) {
+        throw new Error(
+            `${errorMessagePrefix}: ${incompleteParticipants.length} participants have incomplete scores`
+        )
+    }
+}
+
+export async function isTournamentResultsComplete(tournamentId: string): Promise<boolean> {
+    const tournament = await prismaOrThrow("get tournament results complete").tournament.findUnique({
+        where: { id: tournamentId },
+        include: {
+            participants: {
+                where: { checkedIn: true },
+                include: { participantScore: true },
+            },
+        },
+    })
+
+    if (!tournament) {
+        return false
+    }
+
+    return tournament.participants.length > 0 && tournament.participants.every((p) => !!p.participantScore)
+}


### PR DESCRIPTION
## Summary
- Add public **Championship Results** browse page (`/results/championships`) and per-championship detail with day tabs for groups plus combined standings.
- Add championship-level **Sharing** control to publish or link-share all day tournaments at once (no per-tournament score completion gate for championships).
- Extract shared standings pipeline (`championshipStandingsInput`) and tournament sharing helpers; sort combined standings categories by bow, age, then gender.
- ADR M11 milestone docs and patch version bump to 1.4.7.

## Test plan
- [ ] Nav → **Championship Results** lists published championships; **View results** opens detail.
- [ ] Detail tabs: Day 1/2/… show all range groups; **Combined standings** shows sorted categories.
- [ ] Organizer: championship **Sharing** → Link-Shared/Public applies to all days; copy link works.
- [ ] Public link works without login; partial scores still show standings/groups.
- [ ] `npm test` and `npm run build` pass.


Made with [Cursor](https://cursor.com)