### PR TITLE
fix(championships): restore division-range matrix UI improvements

### DIFF
--- a/src/app/championships/[cId]/ChampionshipDivisionRangeMatrix.tsx
+++ b/src/app/championships/[cId]/ChampionshipDivisionRangeMatrix.tsx
@@ -1,12 +1,20 @@
 "use client"
 
 import FormModal, { type FormModalHandle } from "@/components/FormModal"
-import useErrorContext from "@/components/errors/ErrorContext"
+import useErrorContext, { useInfoContext } from "@/components/errors/ErrorContext"
 import { compareDivisionsForMatrix } from "@/lib/championshipDivision"
 import type { GenderGroup } from "@/generated/prisma/client"
-import { isDivisionRangeBlockedOnOtherDay } from "@/lib/championshipRangeRules"
+import {
+    buildCategoryRangeUpdates,
+    categoryHasAssignmentOnFrozenDayOne,
+    collectSoleAvailableRangeAssignments,
+    isDayRangeAssignmentEditable,
+    isDivisionRangeBlockedOnOtherDay,
+    type RangeAssignmentUpdate,
+} from "@/lib/championshipRangeRules"
+import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/outline"
 import { useRouter } from "next/navigation"
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition, type Dispatch, type SetStateAction } from "react"
 import {
     getChampionshipDivisionRangeMatrix,
     setChampionshipDivisionRangeAssignment,
@@ -83,6 +91,80 @@ function RegistrationCountButton({ count, onClick }: { count: number; onClick: (
     )
 }
 
+function CategoryDayQuickAssign({
+    dayOrders,
+    rangeCount,
+    dayOneFrozen,
+    readOnly,
+    isPending,
+    onCategoryDayAction,
+    onClearCategoryDay,
+    onClearCategory,
+}: {
+    dayOrders: number[]
+    rangeCount: number
+    dayOneFrozen: boolean
+    readOnly: boolean
+    isPending: boolean
+    onCategoryDayAction: (dayOrder: number, rangeNumber: number) => void
+    onClearCategoryDay: (dayOrder: number) => void
+    onClearCategory: () => void
+}) {
+    return (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-normal pl-9">
+            <button
+                type="button"
+                className="btn btn-ghost btn-xs min-h-0 h-7 px-1.5"
+                disabled={readOnly || isPending}
+                onClick={onClearCategory}
+            >
+                Clear category
+            </button>
+            {dayOrders.map((dayOrder) => {
+                const editable = isDayRangeAssignmentEditable(dayOrder, dayOneFrozen)
+
+                return (
+                    <div key={dayOrder} className="flex items-center gap-1">
+                        <span className="text-base-content/70">D{dayOrder}</span>
+                        <select
+                            className="select select-bordered select-xs w-[4.75rem] min-h-0 h-7 px-1"
+                            disabled={readOnly || isPending || !editable}
+                            aria-label={`Assign all divisions on day ${dayOrder}`}
+                            defaultValue=""
+                            onChange={(event) => {
+                                const value = event.target.value
+                                if (value === "") {
+                                    return
+                                }
+                                onCategoryDayAction(dayOrder, Number(value))
+                                event.target.value = ""
+                            }}
+                        >
+                            <option value="">All →</option>
+                            {Array.from({ length: rangeCount }, (_, index) => {
+                                const rangeNumber = index + 1
+                                return (
+                                    <option key={rangeNumber} value={rangeNumber}>
+                                        R{rangeNumber}
+                                    </option>
+                                )
+                            })}
+                        </select>
+                        <button
+                            type="button"
+                            className="btn btn-ghost btn-xs min-h-0 h-7 px-1.5"
+                            disabled={readOnly || isPending || !editable}
+                            onClick={() => onClearCategoryDay(dayOrder)}
+                        >
+                            Clear D{dayOrder}
+                        </button>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
 function RangeSelect({
     divisionKey,
     dayOrder,
@@ -91,6 +173,7 @@ function RangeSelect({
     rangeCount,
     frozen,
     readOnly,
+    isPending,
     onChange,
 }: {
     divisionKey: string
@@ -100,13 +183,14 @@ function RangeSelect({
     rangeCount: number
     frozen: boolean
     readOnly: boolean
+    isPending: boolean
     onChange: (divisionKey: string, dayOrder: number, rangeNumber: number | null) => void
 }) {
     return (
         <select
             className="select select-bordered select-xs w-14 min-h-0 h-8 px-1"
             value={rangeNumber ?? ""}
-            disabled={readOnly || frozen}
+            disabled={readOnly || isPending || frozen}
             aria-label={`Day ${dayOrder} range for ${divisionKey}`}
             onChange={(event) => {
                 const value = event.target.value
@@ -161,11 +245,19 @@ function DayRangeTotals({
 function DivisionRangeTotalsHeader({
     dayOrders,
     totalsByDay,
+    dayOneFrozen,
+    readOnly,
+    isPending,
     onRangeDayClick,
+    onClearDay,
 }: {
     dayOrders: number[]
     totalsByDay: DivisionRangeMatrixData["totalsByDay"]
+    dayOneFrozen: boolean
+    readOnly: boolean
+    isPending: boolean
     onRangeDayClick: (dayOrder: number, rangeNumber: number) => void
+    onClearDay: (dayOrder: number) => void
 }) {
     return (
         <div className="overflow-x-auto">
@@ -183,7 +275,19 @@ function DivisionRangeTotalsHeader({
                         <th />
                         {dayOrders.map((dayOrder) => (
                             <th key={dayOrder} className="text-center font-normal text-base-content/70">
-                                D{dayOrder}
+                                <div className="flex flex-col items-center gap-1">
+                                    <span>D{dayOrder}</span>
+                                    {!readOnly && isDayRangeAssignmentEditable(dayOrder, dayOneFrozen) ? (
+                                        <button
+                                            type="button"
+                                            className="btn btn-ghost btn-xs min-h-0 h-6 px-1 font-normal"
+                                            disabled={isPending}
+                                            onClick={() => onClearDay(dayOrder)}
+                                        >
+                                            Clear day
+                                        </button>
+                                    ) : null}
+                                </div>
                             </th>
                         ))}
                     </tr>
@@ -294,7 +398,8 @@ function DivisionRangeMatrixTable({
                                         rangeByDay={row.rangeByDay}
                                         rangeCount={rangeCount}
                                         frozen={dayOneFrozen && dayOrder === 1}
-                                        readOnly={readOnly || isPending}
+                                        readOnly={readOnly}
+                                        isPending={isPending}
                                         onChange={onRangeChange}
                                     />
                                 </td>
@@ -340,7 +445,6 @@ function groupRowsByBowStyle(rows: DivisionRangeMatrixRow[]): MatrixBowStyleGrou
 
 function BowStyleAccordion({
     groups,
-    accordionName,
     dayOrders,
     rangeCount,
     dayOneFrozen,
@@ -349,9 +453,11 @@ function BowStyleAccordion({
     onRangeChange,
     onShowParticipants,
     onShowBowStyleParticipants,
+    onCategoryDayAction,
+    onClearCategoryDay,
+    onClearCategory,
 }: {
     groups: MatrixBowStyleGroup[]
-    accordionName: string
     dayOrders: number[]
     rangeCount: number
     dayOneFrozen: boolean
@@ -360,50 +466,215 @@ function BowStyleAccordion({
     onRangeChange: (divisionKey: string, dayOrder: number, rangeNumber: number | null) => void
     onShowParticipants: (abbrev: string, divisionKey: string) => void
     onShowBowStyleParticipants: (categoryName: string, rows: DivisionRangeMatrixRow[]) => void
+    onCategoryDayAction: (rows: DivisionRangeMatrixRow[], dayOrder: number, rangeNumber: number) => void
+    onClearCategoryDay: (rows: DivisionRangeMatrixRow[], dayOrder: number) => void
+    onClearCategory: (rows: DivisionRangeMatrixRow[]) => void
 }) {
+    const [openCategoryId, setOpenCategoryId] = useState<string | null>(() => groups[0]?.categoryId ?? null)
+
+    useEffect(() => {
+        if (groups.length === 0) {
+            setOpenCategoryId(null)
+            return
+        }
+        if (openCategoryId === null || !groups.some((group) => group.categoryId === openCategoryId)) {
+            setOpenCategoryId(groups[0].categoryId)
+        }
+    }, [groups, openCategoryId])
+
     return (
         <div className="flex flex-col gap-2">
-            {groups.map((group, index) => (
-                <div
-                    key={group.categoryId}
-                    className="collapse collapse-arrow bg-base-100 border border-base-300"
-                >
-                    <input
-                        type="radio"
-                        name={accordionName}
-                        defaultChecked={index === 0}
-                        aria-label={`${group.categoryName}, ${group.participantCount} registered`}
-                    />
-                    <div className="collapse-title flex flex-wrap items-center gap-2 pr-8 font-medium">
-                        <span>{group.categoryName}</span>
-                        <button
-                            type="button"
-                            className="badge badge-neutral badge-sm font-normal hover:badge-neutral-focus"
-                            title={`View ${group.participantCount} registered competitors`}
-                            onClick={(event) => {
-                                event.preventDefault()
-                                onShowBowStyleParticipants(group.categoryName, group.rows)
-                            }}
-                        >
-                            {group.participantCount} registered
-                        </button>
+            {groups.map((group) => {
+                const isOpen = openCategoryId === group.categoryId
+
+                return (
+                    <div key={group.categoryId} className="rounded-lg border border-base-300 bg-base-100">
+                        <div className="flex flex-col gap-2 p-4">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <button
+                                    type="button"
+                                    className="btn btn-ghost btn-xs btn-square shrink-0"
+                                    aria-expanded={isOpen}
+                                    aria-label={`${isOpen ? "Collapse" : "Expand"} ${group.categoryName}`}
+                                    onClick={() =>
+                                        setOpenCategoryId(isOpen ? null : group.categoryId)
+                                    }
+                                >
+                                    {isOpen ? (
+                                        <ChevronDownIcon className="w-4 h-4" />
+                                    ) : (
+                                        <ChevronRightIcon className="w-4 h-4" />
+                                    )}
+                                </button>
+                                <span className="font-medium">{group.categoryName}</span>
+                                <button
+                                    type="button"
+                                    className="badge badge-neutral badge-sm font-normal hover:badge-neutral-focus"
+                                    title={`View ${group.participantCount} registered competitors`}
+                                    onClick={() =>
+                                        onShowBowStyleParticipants(group.categoryName, group.rows)
+                                    }
+                                >
+                                    {group.participantCount} registered
+                                </button>
+                            </div>
+                            {!readOnly ? (
+                                <CategoryDayQuickAssign
+                                    dayOrders={dayOrders}
+                                    rangeCount={rangeCount}
+                                    dayOneFrozen={dayOneFrozen}
+                                    readOnly={readOnly}
+                                    isPending={isPending}
+                                    onCategoryDayAction={(dayOrder, rangeNumber) =>
+                                        onCategoryDayAction(group.rows, dayOrder, rangeNumber)
+                                    }
+                                    onClearCategoryDay={(dayOrder) =>
+                                        onClearCategoryDay(group.rows, dayOrder)
+                                    }
+                                    onClearCategory={() => onClearCategory(group.rows)}
+                                />
+                            ) : null}
+                        </div>
+                        {isOpen ? (
+                            <div className="px-4 pb-4">
+                                <DivisionRangeMatrixTable
+                                    rows={group.rows}
+                                    dayOrders={dayOrders}
+                                    rangeCount={rangeCount}
+                                    dayOneFrozen={dayOneFrozen}
+                                    readOnly={readOnly}
+                                    isPending={isPending}
+                                    onRangeChange={onRangeChange}
+                                    onShowParticipants={onShowParticipants}
+                                />
+                            </div>
+                        ) : null}
                     </div>
-                    <div className="collapse-content pt-1">
-                        <DivisionRangeMatrixTable
-                            rows={group.rows}
-                            dayOrders={dayOrders}
-                            rangeCount={rangeCount}
-                            dayOneFrozen={dayOneFrozen}
-                            readOnly={readOnly}
-                            isPending={isPending}
-                            onRangeChange={onRangeChange}
-                            onShowParticipants={onShowParticipants}
-                        />
-                    </div>
-                </div>
-            ))}
+                )
+            })}
         </div>
     )
+}
+
+function computeTotalsByDay(
+    dayOrders: number[],
+    rangeCount: number,
+    rows: DivisionRangeMatrixRow[]
+): DivisionRangeMatrixData["totalsByDay"] {
+    const totalsByDay = Object.fromEntries(
+        dayOrders.map((dayOrder) => [
+            dayOrder,
+            Object.fromEntries(Array.from({ length: rangeCount }, (_, index) => [index + 1, 0])) as Record<
+                number,
+                number
+            >,
+        ])
+    ) as DivisionRangeMatrixData["totalsByDay"]
+
+    for (const row of rows) {
+        for (const dayOrder of dayOrders) {
+            const rangeNumber = row.rangeByDay[dayOrder]
+            if (rangeNumber !== null && rangeNumber !== undefined) {
+                totalsByDay[dayOrder][rangeNumber] =
+                    (totalsByDay[dayOrder][rangeNumber] ?? 0) + row.registrationCount
+            }
+        }
+    }
+
+    return totalsByDay
+}
+
+function matrixWithAssignments(
+    matrix: DivisionRangeMatrixData,
+    assignments: RangeAssignmentUpdate[]
+): DivisionRangeMatrixData {
+    if (assignments.length === 0) {
+        return matrix
+    }
+
+    const rows = matrix.rows.map((row) => {
+        const updates = assignments.filter((assignment) => assignment.divisionKey === row.divisionKey)
+        if (updates.length === 0) {
+            return row
+        }
+
+        const rangeByDay = { ...row.rangeByDay }
+        for (const update of updates) {
+            rangeByDay[update.dayOrder] = update.rangeNumber
+        }
+
+        return { ...row, rangeByDay }
+    })
+
+    return {
+        ...matrix,
+        rows,
+        totalsByDay: computeTotalsByDay(matrix.dayOrders, matrix.rangeCount, rows),
+    }
+}
+
+async function persistRangeAssignments(
+    championshipId: string,
+    assignments: RangeAssignmentUpdate[]
+): Promise<void> {
+    for (const assignment of assignments) {
+        await setChampionshipDivisionRangeAssignment(
+            championshipId,
+            assignment.dayOrder,
+            assignment.divisionKey,
+            assignment.rangeNumber
+        )
+    }
+}
+
+async function applyRangeAssignmentsWithAutoFill({
+    championshipId,
+    assignments,
+    reloadMatrix,
+    setMatrix,
+    routerRefresh,
+}: {
+    championshipId: string
+    assignments: RangeAssignmentUpdate[]
+    reloadMatrix: () => Promise<DivisionRangeMatrixData | null>
+    setMatrix: Dispatch<SetStateAction<DivisionRangeMatrixData | null>>
+    routerRefresh: () => void
+}): Promise<DivisionRangeMatrixData | null> {
+    if (assignments.length === 0) {
+        return reloadMatrix()
+    }
+
+    setMatrix((current) => (current ? matrixWithAssignments(current, assignments) : current))
+    await persistRangeAssignments(championshipId, assignments)
+
+    let currentMatrix = await reloadMatrix()
+    const shouldAutoFill = assignments.some((assignment) => assignment.rangeNumber !== null)
+
+    if (shouldAutoFill && currentMatrix) {
+        let autoAssignments = collectSoleAvailableRangeAssignments(
+            currentMatrix.rows,
+            currentMatrix.dayOrders,
+            currentMatrix.rangeCount,
+            currentMatrix.dayOneFrozen
+        )
+
+        let passes = 0
+        while (autoAssignments.length > 0 && passes < currentMatrix.dayOrders.length) {
+            setMatrix(matrixWithAssignments(currentMatrix, autoAssignments))
+            await persistRangeAssignments(championshipId, autoAssignments)
+            currentMatrix = (await reloadMatrix()) ?? currentMatrix
+            autoAssignments = collectSoleAvailableRangeAssignments(
+                currentMatrix.rows,
+                currentMatrix.dayOrders,
+                currentMatrix.rangeCount,
+                currentMatrix.dayOneFrozen
+            )
+            passes += 1
+        }
+    }
+
+    routerRefresh()
+    return currentMatrix
 }
 
 function matrixRowAsDivision(row: DivisionRangeMatrixRow) {
@@ -429,13 +700,26 @@ export default function ChampionshipDivisionRangeMatrix({
 }) {
     const router = useRouter()
     const setError = useErrorContext()
+    const setInfo = useInfoContext()
     const participantsModalRef = useRef<FormModalHandle>(null)
+    const skipNextInitialMatrixSyncRef = useRef(false)
+    const initialAutoFillDoneRef = useRef(false)
+    const matrixRef = useRef<DivisionRangeMatrixData | null>(initialMatrix)
     const [matrix, setMatrix] = useState<DivisionRangeMatrixData | null>(initialMatrix)
     const [modalView, setModalView] = useState<MatrixModalView | null>(null)
     const [isPending, startTransition] = useTransition()
 
     useEffect(() => {
+        matrixRef.current = matrix
+    }, [matrix])
+
+    useEffect(() => {
+        if (skipNextInitialMatrixSyncRef.current) {
+            skipNextInitialMatrixSyncRef.current = false
+            return
+        }
         setMatrix(initialMatrix)
+        matrixRef.current = initialMatrix
     }, [initialMatrix])
 
     const bowStyleGroups = useMemo(
@@ -509,24 +793,171 @@ export default function ChampionshipDivisionRangeMatrix({
     const reloadMatrix = useCallback(() => {
         return getChampionshipDivisionRangeMatrix(championshipId).then((data) => {
             if (data) {
+                matrixRef.current = data
                 setMatrix(data)
             }
             return data
         })
     }, [championshipId])
 
+    const applyRangeAssignments = useCallback(
+        (assignments: RangeAssignmentUpdate[]) => {
+            if (assignments.length === 0) {
+                return Promise.resolve(matrixRef.current)
+            }
+
+            skipNextInitialMatrixSyncRef.current = true
+            setError(undefined)
+
+            return applyRangeAssignmentsWithAutoFill({
+                championshipId,
+                assignments,
+                reloadMatrix,
+                setMatrix,
+                routerRefresh: () => router.refresh(),
+            })
+        },
+        [championshipId, reloadMatrix, router, setError]
+    )
+
     const handleRangeChange = (divisionKey: string, dayOrder: number, rangeNumber: number | null) => {
         startTransition(() => {
-            setChampionshipDivisionRangeAssignment(championshipId, dayOrder, divisionKey, rangeNumber)
+            applyRangeAssignments([{ divisionKey, dayOrder, rangeNumber }]).catch((error) => {
+                setError(error instanceof Error ? error.message : "Unable to update range assignment")
+            })
+        })
+    }
+
+    const applyCategoryUpdates = (
+        rows: DivisionRangeMatrixRow[],
+        dayOrder: number | "all",
+        rangeNumber: number | null,
+        emptyMessage: string,
+        successMessage?: string
+    ) => {
+        const current = matrixRef.current
+        if (!current) {
+            return
+        }
+
+        const assignments = buildCategoryRangeUpdates(
+            rows,
+            current.dayOrders,
+            dayOrder,
+            rangeNumber,
+            current.dayOneFrozen
+        )
+
+        if (assignments.length === 0) {
+            setInfo(emptyMessage)
+            return
+        }
+
+        setInfo(undefined)
+        startTransition(() => {
+            applyRangeAssignments(assignments)
                 .then(() => {
-                    router.refresh()
-                    return reloadMatrix()
+                    if (successMessage) {
+                        setInfo(successMessage)
+                    }
                 })
                 .catch((error) => {
-                    setError(error instanceof Error ? error.message : "Unable to update range assignment")
+                    setError(error instanceof Error ? error.message : "Unable to update range assignments")
                 })
         })
     }
+
+    const handleCategoryDayAction = (
+        rows: DivisionRangeMatrixRow[],
+        dayOrder: number,
+        rangeNumber: number
+    ) => {
+        applyCategoryUpdates(
+            rows,
+            dayOrder,
+            rangeNumber,
+            `No divisions in this category could be assigned to range ${rangeNumber} on day ${dayOrder} (already set or blocked on another day).`
+        )
+    }
+
+    const handleClearCategoryDay = (rows: DivisionRangeMatrixRow[], dayOrder: number) => {
+        applyCategoryUpdates(
+            rows,
+            dayOrder,
+            null,
+            `No divisions in this category have an assignment on day ${dayOrder} to clear.`
+        )
+    }
+
+    const handleClearCategory = (rows: DivisionRangeMatrixRow[]) => {
+        const current = matrixRef.current
+        if (!current) {
+            return
+        }
+
+        const skippedFrozenDayOne = categoryHasAssignmentOnFrozenDayOne(rows, current.dayOneFrozen)
+        applyCategoryUpdates(
+            rows,
+            "all",
+            null,
+            "No assignments in this category to clear.",
+            skippedFrozenDayOne
+                ? "Cleared this category on all editable days. Day 1 assignments are frozen and were not changed."
+                : undefined
+        )
+    }
+
+    const handleClearDay = (dayOrder: number) => {
+        const current = matrixRef.current
+        if (!current) {
+            return
+        }
+
+        const assignments = buildCategoryRangeUpdates(
+            current.rows,
+            current.dayOrders,
+            dayOrder,
+            null,
+            current.dayOneFrozen
+        )
+
+        if (assignments.length === 0) {
+            setInfo(`No assignments on day ${dayOrder} to clear.`)
+            return
+        }
+
+        setInfo(undefined)
+        startTransition(() => {
+            applyRangeAssignments(assignments).catch((error) => {
+                setError(error instanceof Error ? error.message : "Unable to clear day assignments")
+            })
+        })
+    }
+
+    useEffect(() => {
+        if (initialAutoFillDoneRef.current || !matrix || readOnly) {
+            return
+        }
+
+        initialAutoFillDoneRef.current = true
+
+        const autoAssignments = collectSoleAvailableRangeAssignments(
+            matrix.rows,
+            matrix.dayOrders,
+            matrix.rangeCount,
+            matrix.dayOneFrozen
+        )
+
+        if (autoAssignments.length === 0) {
+            return
+        }
+
+        startTransition(() => {
+            applyRangeAssignments(autoAssignments).catch((error) => {
+                setError(error instanceof Error ? error.message : "Unable to update range assignment")
+            })
+        })
+    }, [applyRangeAssignments, matrix, readOnly, setError])
 
     if (!matrix || matrix.rows.length === 0) {
         return null
@@ -544,13 +975,16 @@ export default function ChampionshipDivisionRangeMatrix({
                     <DivisionRangeTotalsHeader
                         dayOrders={matrix.dayOrders}
                         totalsByDay={matrix.totalsByDay}
+                        dayOneFrozen={matrix.dayOneFrozen}
+                        readOnly={readOnly}
+                        isPending={isPending}
                         onRangeDayClick={openRangeDayParticipants}
+                        onClearDay={handleClearDay}
                     />
                 </div>
             </div>
             <BowStyleAccordion
                 groups={bowStyleGroups}
-                accordionName={`division-range-bow-styles-${championshipId}`}
                 dayOrders={matrix.dayOrders}
                 rangeCount={matrix.rangeCount}
                 dayOneFrozen={matrix.dayOneFrozen}
@@ -559,6 +993,9 @@ export default function ChampionshipDivisionRangeMatrix({
                 onRangeChange={handleRangeChange}
                 onShowParticipants={openDivisionParticipants}
                 onShowBowStyleParticipants={openBowStyleParticipants}
+                onCategoryDayAction={handleCategoryDayAction}
+                onClearCategoryDay={handleClearCategoryDay}
+                onClearCategory={handleClearCategory}
             />
             <p className="text-sm text-base-content/70">
                 Assign every division to a range on each day before enrolling competitors on multi-range championships.

--- a/src/lib/__tests__/championshipRangeRules.test.ts
+++ b/src/lib/__tests__/championshipRangeRules.test.ts
@@ -1,10 +1,15 @@
 import {
+    buildCategoryRangeUpdates,
+    canAssignDivisionRangeOnDay,
     canEnrollDivisionOnDay,
+    collectSoleAvailableRangeAssignments,
     findDivisionRangeOnOtherDay,
     isDivisionRangeAssignmentComplete,
     isDivisionRangeBlockedOnOtherDay,
     mapDivisionRangeAssignments,
     resolveDivisionRangeForDay,
+    shouldApplyRangeOnDay,
+    soleAvailableRangeForDay,
 } from "@/lib/championshipRangeRules"
 
 const assignments = [
@@ -60,6 +65,75 @@ describe("isDivisionRangeBlockedOnOtherDay", () => {
     it("blocks ranges already assigned on another day for the row", () => {
         expect(isDivisionRangeBlockedOnOtherDay({ 1: 1, 2: null }, 2, 1)).toBe(true)
         expect(isDivisionRangeBlockedOnOtherDay({ 1: 1, 2: null }, 2, 2)).toBe(false)
+    })
+})
+
+describe("soleAvailableRangeForDay", () => {
+    it("returns the only range left when other days block the rest", () => {
+        expect(soleAvailableRangeForDay({ 1: 1, 2: null }, 2, 2)).toBe(2)
+    })
+
+    it("returns null when multiple ranges are still available", () => {
+        expect(soleAvailableRangeForDay({ 1: null, 2: null }, 1, 2)).toBeNull()
+    })
+
+    it("returns null when the day is already assigned", () => {
+        expect(soleAvailableRangeForDay({ 1: 1, 2: null }, 1, 2)).toBeNull()
+    })
+})
+
+describe("collectSoleAvailableRangeAssignments", () => {
+    it("collects unassigned cells with exactly one valid range", () => {
+        expect(
+            collectSoleAvailableRangeAssignments(
+                [{ divisionKey: "age-1:M:cat-1", rangeByDay: { 1: 1, 2: null } }],
+                [1, 2],
+                2,
+                false
+            )
+        ).toEqual([{ divisionKey: "age-1:M:cat-1", dayOrder: 2, rangeNumber: 2 }])
+    })
+})
+
+describe("canAssignDivisionRangeOnDay", () => {
+    it("allows assigning a free range on an editable day", () => {
+        expect(canAssignDivisionRangeOnDay({ 1: 1, 2: null }, 2, 2, false)).toBe(true)
+    })
+
+    it("rejects blocked ranges and frozen day 1", () => {
+        expect(canAssignDivisionRangeOnDay({ 1: 1, 2: null }, 2, 1, false)).toBe(false)
+        expect(canAssignDivisionRangeOnDay({ 1: null, 2: null }, 1, 1, true)).toBe(false)
+    })
+})
+
+describe("buildCategoryRangeUpdates", () => {
+    const rows = [
+        { divisionKey: "age-1:M:cat-1", rangeByDay: { 1: 1, 2: 2 } },
+        { divisionKey: "age-2:M:cat-1", rangeByDay: { 1: 1, 2: null } },
+    ]
+
+    it("clears every assigned day in the category", () => {
+        expect(buildCategoryRangeUpdates(rows, [1, 2], "all", null, false)).toEqual([
+            { divisionKey: "age-1:M:cat-1", dayOrder: 1, rangeNumber: null },
+            { divisionKey: "age-1:M:cat-1", dayOrder: 2, rangeNumber: null },
+            { divisionKey: "age-2:M:cat-1", dayOrder: 1, rangeNumber: null },
+        ])
+    })
+
+    it("skips frozen day 1 when clearing the whole category", () => {
+        expect(buildCategoryRangeUpdates(rows, [1, 2], "all", null, true)).toEqual([
+            { divisionKey: "age-1:M:cat-1", dayOrder: 2, rangeNumber: null },
+        ])
+    })
+})
+
+describe("shouldApplyRangeOnDay", () => {
+    it("allows clearing an assigned day", () => {
+        expect(shouldApplyRangeOnDay({ 1: 1, 2: 2 }, 2, null, false)).toBe(true)
+    })
+
+    it("skips clear when the day is already empty", () => {
+        expect(shouldApplyRangeOnDay({ 1: 1, 2: null }, 2, null, false)).toBe(false)
     })
 })
 

--- a/src/lib/championshipRangeRules.ts
+++ b/src/lib/championshipRangeRules.ts
@@ -78,6 +78,140 @@ export function isDivisionRangeBlockedOnOtherDay(
     )
 }
 
+export function availableRangesForDay(
+    rangeByDay: Record<number, number | null>,
+    dayOrder: number,
+    rangeCount: number
+): number[] {
+    const ranges: number[] = []
+    for (let rangeNumber = 1; rangeNumber <= rangeCount; rangeNumber += 1) {
+        if (!isDivisionRangeBlockedOnOtherDay(rangeByDay, dayOrder, rangeNumber)) {
+            ranges.push(rangeNumber)
+        }
+    }
+    return ranges
+}
+
+export function soleAvailableRangeForDay(
+    rangeByDay: Record<number, number | null>,
+    dayOrder: number,
+    rangeCount: number
+): number | null {
+    if (rangeByDay[dayOrder] != null) {
+        return null
+    }
+
+    const available = availableRangesForDay(rangeByDay, dayOrder, rangeCount)
+    return available.length === 1 ? available[0]! : null
+}
+
+export type SoleAvailableRangeAssignment = {
+    divisionKey: string
+    dayOrder: number
+    rangeNumber: number
+}
+
+export function collectSoleAvailableRangeAssignments(
+    rows: { divisionKey: string; rangeByDay: Record<number, number | null> }[],
+    dayOrders: number[],
+    rangeCount: number,
+    dayOneFrozen: boolean
+): SoleAvailableRangeAssignment[] {
+    const assignments: SoleAvailableRangeAssignment[] = []
+
+    for (const row of rows) {
+        for (const dayOrder of dayOrders) {
+            if (dayOneFrozen && dayOrder === 1) {
+                continue
+            }
+
+            const rangeNumber = soleAvailableRangeForDay(row.rangeByDay, dayOrder, rangeCount)
+            if (rangeNumber !== null) {
+                assignments.push({ divisionKey: row.divisionKey, dayOrder, rangeNumber })
+            }
+        }
+    }
+
+    return assignments
+}
+
+export function isDayRangeAssignmentEditable(dayOrder: number, dayOneFrozen: boolean): boolean {
+    return !(dayOneFrozen && dayOrder === 1)
+}
+
+export function shouldApplyRangeOnDay(
+    rangeByDay: Record<number, number | null>,
+    dayOrder: number,
+    rangeNumber: number | null,
+    dayOneFrozen: boolean
+): boolean {
+    if (!isDayRangeAssignmentEditable(dayOrder, dayOneFrozen)) {
+        return false
+    }
+
+    const current = rangeByDay[dayOrder] ?? null
+    if (rangeNumber === null) {
+        return current !== null
+    }
+
+    if (current === rangeNumber) {
+        return false
+    }
+
+    return !isDivisionRangeBlockedOnOtherDay(rangeByDay, dayOrder, rangeNumber)
+}
+
+export type RangeAssignmentUpdate = {
+    divisionKey: string
+    dayOrder: number
+    rangeNumber: number | null
+}
+
+export function buildCategoryRangeUpdates(
+    rows: { divisionKey: string; rangeByDay: Record<number, number | null> }[],
+    dayOrders: number[],
+    dayOrder: number | "all",
+    rangeNumber: number | null,
+    dayOneFrozen: boolean
+): RangeAssignmentUpdate[] {
+    const targetDays = dayOrder === "all" ? dayOrders : [dayOrder]
+    const updates: RangeAssignmentUpdate[] = []
+
+    for (const row of rows) {
+        for (const targetDay of targetDays) {
+            if (shouldApplyRangeOnDay(row.rangeByDay, targetDay, rangeNumber, dayOneFrozen)) {
+                updates.push({
+                    divisionKey: row.divisionKey,
+                    dayOrder: targetDay,
+                    rangeNumber,
+                })
+            }
+        }
+    }
+
+    return updates
+}
+
+export function categoryHasAssignmentOnFrozenDayOne(
+    rows: { rangeByDay: Record<number, number | null> }[],
+    dayOneFrozen: boolean
+): boolean {
+    if (!dayOneFrozen) {
+        return false
+    }
+
+    return rows.some((row) => row.rangeByDay[1] != null)
+}
+
+export function canAssignDivisionRangeOnDay(
+    rangeByDay: Record<number, number | null>,
+    dayOrder: number,
+    rangeNumber: number,
+    dayOneFrozen: boolean
+): boolean {
+    return shouldApplyRangeOnDay(rangeByDay, dayOrder, rangeNumber, dayOneFrozen)
+}
+
 export function resolveDivisionRangeForDay(
     assignments: ChampionshipDivisionRangeRow[],
     rangeCount: number,


### PR DESCRIPTION
Recover bulk category assign, auto-fill sole range, clear actions, controlled category panels, and optimistic matrix updates that were dropped from M11 split.